### PR TITLE
Adding a command line easy upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,20 @@ This is a stable and viable workaround to leverage Module Federation [until this
 #### Demo
 You can see it in action here: https://github.com/module-federation/module-federation-examples/tree/master/nextjs
 
-## How to use it
+## How to use on a fresh nextjs app
+
+```sh
+yarn global add @module-federation/nextjs-mf@0.0.1-beta.4
+```
+
+Run this inside of a fresh nextjs install.
+
+```sh
+nextjs-mf upgrade -p 3001
+```
+
+## How to use on an existing app
+
 1. Install Next ^9.5.6 (currently in canary)
 2. Use `withModuleFederation` in your `next.config.js`
 

--- a/bin/nextjs-mf.js
+++ b/bin/nextjs-mf.js
@@ -1,0 +1,98 @@
+#!node
+const { Command } = require("commander");
+const program = new Command();
+const path = require("path");
+const fs = require("fs");
+
+program.version(require(path.resolve(__dirname, "../package.json")).version);
+
+const nextConfigJS = ({ name, port }) => `const {
+  withModuleFederation,
+  MergeRuntime,
+} = require("@module-federation/nextjs-mf");
+const path = require("path");
+
+module.exports = {
+  webpack: (config, options) => {
+    const { buildId, dev, isServer, defaultLoaders, webpack } = options;
+    const mfConf = {
+      name: "${name}",
+      library: { type: config.output.libraryTarget, name: "${name}" },
+      filename: "static/runtime/remoteEntry.js",
+      remotes: {
+        // test1: isServer
+        //   ? path.resolve(
+        //       __dirname,
+        //       "../test1/.next/server/static/runtime/remoteEntry.js"
+        //     )
+        //   : "test1", // for client, treat it as a global
+      },
+      exposes: {},
+      shared: [],
+    };
+
+    // Configures ModuleFederation and other Webpack properties
+    withModuleFederation(config, options, mfConf);
+
+    config.plugins.push(new MergeRuntime());
+
+    if (!isServer) {
+      config.output.publicPath = "http://localhost:${port}/_next/";
+    }
+
+    return config;
+  },
+};`;
+
+const documentJS = () => `import Document, { Html, Head, Main, NextScript } from "next/document";
+import { patchSharing } from "@module-federation/nextjs-mf";
+
+class MyDocument extends Document {
+  static async getInitialProps(ctx) {
+    const initialProps = await Document.getInitialProps(ctx);
+    return { ...initialProps };
+  }
+
+  render() {
+    return (
+      <Html>
+        {patchSharing()}
+        {/* <script src="http://localhost:3000/_next/static/remoteEntryMerged.js" /> */}
+        <Head />
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    );
+  }
+}
+
+export default MyDocument;`;
+
+const upgrade = ({ port: p }) => {
+  const port = p || 3000;
+
+  // Upgrade package.json
+  const pkgJSON = JSON.parse(fs.readFileSync("package.json").toString());
+  const name = pkgJSON.name;
+  pkgJSON.resolutions = {
+    webpack: "5.1.3",
+    next: "9.5.5",
+  };
+  pkgJSON.scripts.dev = `next dev -p ${port}`;
+  pkgJSON.dependencies.next = "^9.5.6-canary.0";
+  pkgJSON.dependencies["@module-federation/nextjs-mf"] = "0.0.1-beta.4";
+  fs.writeFileSync("package.json", JSON.stringify(pkgJSON, null, 2));
+
+  fs.writeFileSync("next.config.js", nextConfigJS({ name, port }));
+  fs.writeFileSync("pages/_document.js", documentJS({ name, port }));
+};
+
+program
+  .command("upgrade")
+  .description("upgrade the NextJS instance in the current directory")
+  .option("-p, --port <port>", "port")
+  .action(upgrade);
+
+program.parse(process.argv);

--- a/package.json
+++ b/package.json
@@ -10,7 +10,11 @@
   "scripts": {
     "prettier": "prettier --write \"**/*.{js,json,md,ts,tsx}\""
   },
+  "bin": {
+    "nextjs-mf": "./bin/nextjs-mf.js"
+  },
   "devDependencies": {
+    "commander": "^6.2.0",
     "prettier": "^2.1.2",
     "react": "^17.0.1"
   },


### PR DESCRIPTION
Adding a `nextjs-mf` command line function that you can use on a fresh `create-next-app` and upgrade it to support Module Federation.