### PR TITLE
fix(patch): use with next as external module

### DIFF
--- a/patchSharing.js
+++ b/patchSharing.js
@@ -1,8 +1,12 @@
 const path = require("path");
 const fs = require("fs");
+const __require__ =
+  typeof __non_webpack_require__ !== "undefined"
+    ? __non_webpack_require__
+    : require;
 const patchSharing = () => {
   const React = require("react");
-  const reactPath = path.dirname(__non_webpack_require__.resolve("react"));
+  const reactPath = path.dirname(__require__.resolve("react"));
   const umdReact =
     process.env.NODE_ENV === "production"
       ? path.join(reactPath, "umd/react.production.min.js")


### PR DESCRIPTION
Hello, when I use Module Federation Plugin only on client-side, the module `next` is set as external so `__non_webpack_require__` is undefined.
This change fallbacks to a regular `require` in this case.