### PR TITLE
fix(command): Move commander as dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "nextjs-mf": "./bin/nextjs-mf.js"
   },
   "devDependencies": {
-    "commander": "^6.2.0",
     "prettier": "^2.1.2",
     "react": "^17.0.1"
   },
@@ -22,6 +21,7 @@
     "react": "^16 || ^17"
   },
   "dependencies": {
-    "shelljs": "^0.8.4"
+    "shelljs": "^0.8.4",
+    "commander": "^6.2.0"
   }
 }


### PR DESCRIPTION
This Fixes the issue #27 

Commander is required as dependencies in order to upgrade