### PR TITLE
fix(merge-runtime): use webpack Compilation

### DIFF
--- a/merge-runtime.js
+++ b/merge-runtime.js
@@ -1,21 +1,39 @@
-const ConcatSource = require('webpack-sources/lib/ConcatSource');
+const ConcatSource = require("webpack-sources/lib/ConcatSource");
+const Compilation = require("webpack/lib/Compilation");
 
 module.exports = class ModuleFedSingleRuntimePlugin {
   constructor(options) {
-    this._options = {fileName: 'remoteEntry.js', ...options};
+    this._options = { fileName: "static/runtime/remoteEntry.js", ...options };
   }
   // Define `apply` as its prototype method which is supplied with compiler as its argument
   apply(compiler) {
     if (!this._options) return null;
-    const options = this._options;
+    const { fileName } = this._options;
 
     // Specify the event hook to attach to
-    compiler.hooks.emit.tap("EnableSingleRunTimeForFederationPlugin", (compilation) => {
-      const { assets } = compilation;
-      const runtime  = assets['runtime.js'];
-      const remoteEntry = assets[this._options.fileName];
-      const mergedSource = new ConcatSource(runtime, remoteEntry);
-      assets[this._options.fileName] = mergedSource;
-    });
+    compiler.hooks.thisCompilation.tap(
+      "EnableSingleRunTimeForFederationPlugin",
+      (compilation) => {
+        compilation.hooks.processAssets.tap(
+          {
+            name: "EnableSingleRunTimeForFederationPlugin",
+            stage: Compilation.PROCESS_ASSETS_STAGE_ADDITIONS,
+          },
+          (assets) => {
+            Object.keys(assets).forEach((asset) => {
+              if (asset.includes("static/chunks/webpack")) {
+                compilation.updateAsset(
+                  fileName,
+                  new ConcatSource(
+                    compilation.getAsset(asset).source.buffer().toString(),
+                    compilation.getAsset(fileName).source.buffer().toString()
+                  )
+                );
+              }
+            });
+          }
+        );
+      }
+    );
   }
 };


### PR DESCRIPTION
This should fix #36.
I used the same method than in the [html-webpack-plugin](https://github.com/jantimon/html-webpack-plugin) package ([see their implementation](https://github.com/jantimon/html-webpack-plugin/blob/master/lib/child-compiler.js#L124)).