### PR TITLE
fix nextjs module federation 

### DIFF
--- a/merge-runtime.js
+++ b/merge-runtime.js
@@ -35,19 +35,21 @@ class ModuleFedSingleRuntimePlugin {
           },
           (assets) => {
             const assetArray = Object.keys(assets);
-            let runtimePath = assetArray.find((asset) => {
-              return asset.includes(this._options.runtime);
-            });
-            let remoteEntryPath = assetArray.find((asset) => {
+            const remoteEntryPath = assetArray.find((asset) => {
               return asset.includes(this._options.fileName);
             });
-            compilation.updateAsset(
-              remoteEntryPath,
-              new ConcatSource(
-                compilation.getAsset(runtimePath).source.buffer().toString(),
-                compilation.getAsset(remoteEntryPath).source.buffer().toString()
-              )
-            );
+            if (remoteEntryPath) {
+              const runtimePath = assetArray.find((asset) => {
+                return asset.includes(this._options.runtime);
+              });
+              compilation.updateAsset(
+                remoteEntryPath,
+                new ConcatSource(
+                  compilation.getAsset(runtimePath).source.buffer().toString(),
+                  compilation.getAsset(remoteEntryPath).source.buffer().toString()
+                )
+              );
+            }
           }
         );
       }

--- a/patchSharing.js
+++ b/patchSharing.js
@@ -3,7 +3,8 @@ const fs = require("fs");
 const patchSharing = () => {
   const React = require("react");
   global.React = React;
-  const reactPath = path.dirname(__non_webpack_require__.resolve("react"));
+  const isWebpack = typeof __non_webpack_require__ === undefined
+  const reactPath = path.dirname(isWebpack ? __non_webpack_require__("react") : require.resolve('react'));
   const umdReact =
     process.env.NODE_ENV === "production"
       ? path.join(reactPath, "umd/react.production.min.js")


### PR DESCRIPTION
# The work resolves 2 issues found

## fix __non_webpack_require__ in undefined

**When module federation is used between 2 nextjs apps the function `patchSharing` errors as `__non_webpack_require__` can be undefined.  This work resolves that issue.**

### With current code:
![image](https://user-images.githubusercontent.com/4889659/119108563-3a001f00-ba18-11eb-9170-f3f906522291.png)

### With code fix:
![image](https://user-images.githubusercontent.com/4889659/119108807-80557e00-ba18-11eb-959d-4f2d6177449b.png)

## fix `MergeRuntime` when filename is not found

**When `mergeRuntime` is enabled in next.config.js for two apps using module federation the build fails as a filename can be undefined when one or more apps does not expose remote files.  This work fixes that issue.**

### With current code: 
![image](https://user-images.githubusercontent.com/4889659/119130125-adf9f180-ba2f-11eb-8a05-56c337749222.png)

### With code fix:
![image](https://user-images.githubusercontent.com/4889659/119130409-177a0000-ba30-11eb-8dbd-b22e2c65f833.png)

