### PR TITLE
(fix) Use same next router in all modules

### DIFF
--- a/next_router_context.js
+++ b/next_router_context.js
@@ -1,0 +1,14 @@
+if (global.NextRouterContext) {
+    module.exports = global.NextRouterContext;
+} else if (process.browser && window.NextRouterContext) {
+    module.exports = window.NextRouterContext;
+} else if (process.browser) {
+    window.NextRouterContext = require("next/dist/next-server/lib/router-context.js");
+    module.exports = window.NextRouterContext;
+} else {
+    var isWebpack = typeof __non_webpack_require__ === undefined
+    global.NextRouterContext = isWebpack
+        ? __non_webpack_require__("next/dist/next-server/lib/router-context.js")
+        : require("next/dist/next-server/lib/router-context.js");
+    module.exports = global.NextRouterContext;
+}

--- a/withModuleFederation.js
+++ b/withModuleFederation.js
@@ -26,9 +26,15 @@ const withModuleFederation = (config, options, mfConfig) => {
   config.experiments = { topLevelAwait: true };
   if (!options.isServer) {
     config.output.uniqueName = mfConfig.name;
-    Object.assign(config.resolve.alias,{ react: require.resolve("./react.js")})
+    Object.assign(config.resolve.alias,{
+      react: require.resolve("./react.js"),
+      '../next-server/lib/router-context': require.resolve("./next_router_context.js"),
+    })
   } else {
-    config.externals.push({react:require.resolve("./react.js")})
+    config.externals.push({
+      react:require.resolve("./react.js"),
+      '../next-server/lib/router-context': require.resolve("./next_router_context.js"),
+    })
   }
   const federationConfig = {
     name: mfConfig.name,


### PR DESCRIPTION
Should fix #37 and #26 . This shares the router from the main app in all other modules. Otherwise the router is not properly initialized in external modules.