### PR TITLE
fix: React resolver in next dev mode

### DIFF
--- a/react.js
+++ b/react.js
@@ -10,7 +10,7 @@ if (global.React) {
   console.log("loading fresh react");
   var isWebpack = typeof __non_webpack_require__ !== "undefined";
   global.React = isWebpack
-    ? __non_webpack_require__("react/cjs/react.production.min")
-    : require("react/cjs/react.production.min");
+    ? __non_webpack_require__(process.env.NODE_ENV === 'development' ? "react/cjs/react.development" : "react/cjs/react.production.min")
+    : require(process.env.NODE_ENV === 'development' ? "react/cjs/react.development" : "react/cjs/react.production.min");
   module.exports = global.React;
 }


### PR DESCRIPTION
React was always resolved to the production bundle. A check for
development NODE_ENV was needed to fix a React version mismatch
issue when running nextjs in dev mode.

In the https://github.com/module-federation/module-federation-examples repo the `nextjs` example is building and working as expected in production build using `yarn build` and `yarn serve`, but `yarn start` which is using `yarn dev` from `next1` and `next2` is broken for me.

After cloning the repo and even moving the `nextjs` example to a separate place and doing `yarn && yarn start` the `next1` app is not building correctly on the server side and throwing this error:

```
Server Error
Error: Minified React error #321; visit https://reactjs.org/docs/error-decoder.html?invariant=321 for the full message or use the non-minified dev environment for full errors and additional helpful warnings.
```

which is apparently:

```
Invalid hook call. Hooks can only be called inside of the body of a function component. This could happen for one of the following reasons: 1. You might have mismatching versions of React and the renderer (such as React DOM) 2. You might be breaking the Rules of Hooks 3. You might have more than one copy of React in the same app See https://reactjs.org/link/invalid-hook-call for tips about how to debug and fix this problem.
```

Callstack from the error on server side is:
```
Error: Minified React error #321; visit https://reactjs.org/docs/error-decoder.html?invariant=321 for the full message or use the non-minified dev environment for full errors and additional helpful warnings.
    at Z (/Users/lazarv/Projects/nextjs-mf-example/next1/node_modules/react/cjs/react.production.min.js:19:404)
    at Object.exports.useRef (/Users/lazarv/Projects/nextjs-mf-example/next1/node_modules/react/cjs/react.production.min.js:25:226)
    at Link (webpack-internal:///./node_modules/next/dist/client/link.js:140:38)
    at processChild (/Users/lazarv/Projects/nextjs-mf-example/next1/node_modules/react-dom/cjs/react-dom-server.node.development.js:3043:14)
    at resolve (/Users/lazarv/Projects/nextjs-mf-example/next1/node_modules/react-dom/cjs/react-dom-server.node.development.js:2960:5)
    at ReactDOMServerRenderer.render (/Users/lazarv/Projects/nextjs-mf-example/next1/node_modules/react-dom/cjs/react-dom-server.node.development.js:3435:22)
    at ReactDOMServerRenderer.read (/Users/lazarv/Projects/nextjs-mf-example/next1/node_modules/react-dom/cjs/react-dom-server.node.development.js:3373:29)
    at renderToString (/Users/lazarv/Projects/nextjs-mf-example/next1/node_modules/react-dom/cjs/react-dom-server.node.development.js:3988:27)
    at Object.renderPage (/Users/lazarv/Projects/nextjs-mf-example/next1/node_modules/next/dist/next-server/server/render.js:54:854)
    at Function.getInitialProps (webpack-internal:///./node_modules/next/dist/pages/_document.js:211:19)
    at Function.getInitialProps (webpack-internal:///./pages/_document.js:20:85)
    at loadGetInitialProps (/Users/lazarv/Projects/nextjs-mf-example/next1/node_modules/next/dist/next-server/lib/utils.js:5:101)
    at renderToHTML (/Users/lazarv/Projects/nextjs-mf-example/next1/node_modules/next/dist/next-server/server/render.js:54:1145)
    at async /Users/lazarv/Projects/nextjs-mf-example/next1/node_modules/next/dist/next-server/server/next-server.js:112:97
    at async /Users/lazarv/Projects/nextjs-mf-example/next1/node_modules/next/dist/next-server/server/next-server.js:105:142
    at async DevServer.renderToHTMLWithComponents (/Users/lazarv/Projects/nextjs-mf-example/next1/node_modules/next/dist/next-server/server/next-server.js:137:387)
```

Versions used:
```
react@16.14.0
react-dom@16.14.0
next@10.2.3
@module-federation/nextjs-mf@1.0.0
webpack@5.36.2
```