### PR TITLE
fix: Use module path for react external

### DIFF
--- a/withModuleFederation.js
+++ b/withModuleFederation.js
@@ -50,7 +50,7 @@ const withModuleFederation = (config, options, mfConfig) => {
       ),
     });
     config.externals.unshift({
-      react: require.resolve("./react.js"),
+      react: path.relative(path.join(config.context, 'node_modules'), require.resolve("./react.js")),
       // "react-dom": require.resolve("./react-dom.js"),
       // "../next-server/lib/router-context": require.resolve(
       //   "./next_router_context.js"


### PR DESCRIPTION
When I run this locally the `require.resolve` works fine, but when I put the frontends into docker containers and load the `static/runtime/remoteEntry.js` it fails because the external uses an absolute path in there. 

This changes the `require` in the `remoteEntry.js` from

```
module.exports = require("/Users/<path-to-project>/node_modules/@module-federation/nextjs-mf/react.js");
```

to

```
module.exports = require("@module-federation/nextjs-mf/react.js");
```