### PR TITLE
update docs to reflect next internal module sharing

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,15 +43,7 @@ module.exports = withFederatedSidecar({
       // Notice shared are NOT eager here.
       requiredVersion: false,
       singleton: true,
-    },
-    "next/dynamic": {
-      requiredVersion: false,
-      singleton: true,
-    },
-    "next/link": {
-      requiredVersion: false,
-      singleton: true,
-    },
+    }
   },
 })({
   // your original next.config.js export
@@ -115,6 +107,7 @@ export default MyDocument;
 5. Add additional share scope to `_app.js` - this ensures next internals are available for the rest of the app
    
 ```js
+// TODO: make this a loader so its automatic
 if (process.browser) {
   //bolt on some next internals that cannot be shared via MF api
   Object.assign(__webpack_share_scopes__.default, {

--- a/README.md
+++ b/README.md
@@ -75,17 +75,7 @@ module.exports = {
             eager: true,
             singleton: true,
             requiredVersion: false,
-          },
-          "next/dynamic": {
-            eager: true,
-            singleton: true,
-            requiredVersion: false,
-          },
-          "next/link": {
-            eager: true,
-            singleton: true,
-            requiredVersion: false,
-          },
+          }
         },
       })
     );
@@ -122,8 +112,34 @@ class MyDocument extends Document {
 
 export default MyDocument;
 ```
-
-5. Use next/dynamic to import from your remotes
+5. Add additional share scope to `_app.js` - this ensures next internals are available for the rest of the app
+   
+```js
+if (process.browser) {
+  //bolt on some next internals that cannot be shared via MF api
+  Object.assign(__webpack_share_scopes__.default, {
+    "next/link": {
+      [next.version]: {
+        loaded: true,
+        get: () => Promise.resolve(() => require("next/link")),
+      },
+    },
+    "next/head": {
+      [next.version]: {
+        loaded: true,
+        get: () => Promise.resolve(() => require("next/head")),
+      },
+    },
+    "next/dynamic": {
+      [next.version]: {
+        loaded: true,
+        get: () => Promise.resolve(() => require("next/dynamic")),
+      },
+    },
+  });
+}
+```
+6. Use next/dynamic to import from your remotes
 
 ```js
 const SampleComponent = dynamic(() => import("next2/sampleComponent"), {

--- a/lib/with-federated-sidecar.js
+++ b/lib/with-federated-sidecar.js
@@ -51,7 +51,21 @@ const withModuleFederation =
                       return true;
                     }
                   );
-
+                  // attach defaults that always need to be shared
+                  Object.assign(federationPluginOptions.shared, {
+                    "next/dynamic": {
+                      requiredVersion: false,
+                      singleton: true,
+                    },
+                    "next/link": {
+                      requiredVersion: false,
+                      singleton: true,
+                    },
+                    "next/head": {
+                      requiredVersion: false,
+                      singleton: true,
+                    },
+                  });
                   /** @type {import("webpack").WebpackOptionsNormalized} */
                   const webpackOptions = {
                     cache: false,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "public": true,
   "name": "@module-federation/nextjs-mf",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Module Federation helper for NextJS",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
in prod mode, next has limitations due to how chunking and tree shaking + sync bootup + aliasing. 

To work around this, we assign internal modules to the share scope at the very start of the application. This is the low-level equivalent of `eager:true` but without altering the chunking mechanism. 

This is okay to do because you will ever only want to use host-only copies of next internals, so re-attaching them to share scope at runtime is fine. 

Eager sharing causes the modules to move around and usually another copy is created in the remote container to ensure its availability. We can replicate this functionality without moving the modules out of the framework bundle by requiring them like normal 