### PR TITLE
fix: container initialization failed - different share scope

### DIFF
--- a/src/NextFederationPlugin.js
+++ b/src/NextFederationPlugin.js
@@ -348,9 +348,7 @@ function generateRemoteTemplate(url, global) {
   return `promise new Promise(function (resolve, reject) {
     var __webpack_error__ = new Error();
     if (typeof ${global} !== 'undefined') return resolve();
-    __webpack_require__.l(
-      ${JSON.stringify(url)},
-      function (event) {
+    __webpack_require__.l(${JSON.stringify(url)}, (event) => {
         if (typeof ${global} !== 'undefined') return resolve();
         var errorType = event && (event.type === 'load' ? 'missing' : event.type);
         var realSrc = event && event.target && event.target.src;
@@ -360,45 +358,9 @@ function generateRemoteTemplate(url, global) {
         __webpack_error__.type = errorType;
         __webpack_error__.request = realSrc;
         reject(__webpack_error__);
-      },
-      ${JSON.stringify(global)},
+      }, ${JSON.stringify(global)},
     );
-  }).then(function () {
-    const proxy = {
-      get: ${global}.get,
-      init: (args) => {
-        const handler = {
-          get(target, prop) {
-            if (target[prop]) {
-              Object.values(target[prop]).forEach(function(o) {
-                if(o.from === '_N_E') {
-                  o.loaded = true
-                }
-              })
-            }
-            return target[prop]
-          },
-          set(target, property, value, receiver) {
-            if (target[property]) {
-              return target[property]
-            }
-            target[property] = value
-            return true
-          }
-        }
-        try {
-          ${global}.init(new Proxy(__webpack_require__.S.default, handler))
-        } catch (e) {
-
-        }
-        ${global}.__initialized = true
-      }
-    }
-    if (!${global}.__initialized) {
-      proxy.init()
-    }
-    return proxy
-  })`;
+  }).then(() => (${global}))`;
 }
 
 function createRuntimeVariables(remotes) {

--- a/src/NextFederationPlugin.js
+++ b/src/NextFederationPlugin.js
@@ -350,7 +350,7 @@ function generateRemoteTemplate(url, global) {
     if (typeof ${global} !== 'undefined') return resolve();
     __webpack_require__.l(
       ${JSON.stringify(url)},
-      async function (event) {
+      function (event) {
         if (typeof ${global} !== 'undefined') return resolve();
         var errorType = event && (event.type === 'load' ? 'missing' : event.type);
         var realSrc = event && event.target && event.target.src;

--- a/src/NextFederationPlugin.js
+++ b/src/NextFederationPlugin.js
@@ -368,7 +368,7 @@ function generateRemoteTemplate(url, global) {
   }).then(function () {
     const proxy = {
       get: ${global}.get,
-      init: (...args) => {
+      init: function(shareScope) {
         const handler = {
           get(target, prop) {
             if (target[prop]) {
@@ -389,7 +389,7 @@ function generateRemoteTemplate(url, global) {
           }
         }
         try {
-          ${global}.init(new Proxy(args[0], handler))
+          ${global}.init(new Proxy(shareScope, handler))
         } catch (e) {
 
         }


### PR DESCRIPTION
This PR addresses the following scenario:

`Host`: Next.js
`Remote1`: Basic React
`Remote2`: Basic React

- `Remote2` defines a button component and exposes it.
- `Remote1` exposes a composed button component, leveraging `Remote2`'s button as a base
- `Host` consumes both buttons on the same page

Without this PR modification, you'll encounter two errors

```
TypeError: Cannot create proxy with a non-object as target or handler
    at Object.init (test.js?ts=1662739775572:126:26)
    at test.js?ts=1662739775572:134:15
    at async Promise.all (index 0)

Error: Container initialization failed as it has already been initialized with a different share scope
    at Object.init (container_entry:22:48)
    at Object.init (test.js?ts=1662739775572:191:21)
    at initFn (webpack.js?ts=1662739775572:390:86)
    at async Promise.all (index 1)
```

As you can see, the button from `Remote1` remains in this broken loading state:

<img width="616" alt="Screen Shot 2022-09-09 at 12 28 42 PM" src="https://user-images.githubusercontent.com/6590356/189397541-51e4dd63-b1c9-4691-be23-c6d3965e04fd.png">

There are actually two options it seems to resolve this, the first is this PR, which resolves the global without touching `get` or `init`; and the other is to remove the logic that calls `generateRemoteTemplate` and just rely on the raw `options.remotes` passed as `remote@http://...`.

Personally I like have the ability to call `promise new Promise` myself, but this will at least fix share scope stuff.
Here's the final output

<img width="618" alt="Screen Shot 2022-09-09 at 12 25 12 PM" src="https://user-images.githubusercontent.com/6590356/189396959-596e7ffc-9db7-4935-a769-c68954ff5c60.png">
