### PR TITLE
feat: Add skipSharingNextInternals extraOption

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ new NextFederationPlugin({
     exposePages: true, // `false` by default
     enableImageLoaderFix: true, // `false` by default
     enableUrlLoaderFix: true, // `false` by default
+    skipSharingNextInternals: true // `false` by default
   },
 });
 ```
@@ -141,6 +142,7 @@ new NextFederationPlugin({
 - `exposePages` – exposes automatically all nextjs pages for you and theirs `./pages-map`.
 - `enableImageLoaderFix` – adds public hostname to all assets bundled by `nextjs-image-loader`. So if you serve remoteEntry from `http://example.com` then all bundled assets will get this hostname in runtime. It's something like Base URL in HTML but for federated modules.
 - `enableUrlLoaderFix` – adds public hostname to all assets bundled by `url-loader`.
+- `skipSharingNextInternals` - skips sharing of common nextjs modules. Helpful when you would like explicit control over shared modules, such as a non-nextjs host with a federated nextjs child application.
 
 ## Demo
 

--- a/demo/3000-home/next.config.js
+++ b/demo/3000-home/next.config.js
@@ -21,6 +21,7 @@ module.exports = {
             exposePages: true,
             enableImageLoaderFix: true,
             enableUrlLoaderFix: true,
+            skipSharingNextInternals: false,
           },
         })
       );

--- a/src/NextFederationPlugin.js
+++ b/src/NextFederationPlugin.js
@@ -220,7 +220,9 @@ class ChildFederation {
             },
             runtime: false,
             shared: {
-              ...externalizedShares,
+              ...(this._extraOptions.skipSharingNextInternals
+                ? {}
+                : externalizedShares),
               ...this._options.shared,
             },
           }),


### PR DESCRIPTION
Adds a new extra option, `skipSharingNextInternals` which the default behavior of sharing common nextjs modules when specified. This is useful in cases where explicit control of shared modules is helpful, such as with a react host and nextjs child application.

Fixes https://github.com/module-federation/nextjs-mf/issues/140