### PR TITLE
[SSR] Global remote config registry

### DIFF
--- a/demo/3000-home/next.config.js
+++ b/demo/3000-home/next.config.js
@@ -8,9 +8,6 @@ module.exports = {
         name: 'home_app',
         filename: 'static/chunks/remoteEntry.js',
         remotes: {
-          home: `home_app@http://localhost:3000/_next/static/${
-            isServer ? 'ssr' : 'chunks'
-          }/remoteEntry.js`,
           shop: `shop@http://localhost:3001/_next/static/${
             isServer ? 'ssr' : 'chunks'
           }/remoteEntry.js`,

--- a/demo/yarn.lock
+++ b/demo/yarn.lock
@@ -370,11 +370,6 @@
   resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.2.tgz#d291c6a4e97989b5c61d9acf396ae4fe133a718d"
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
 
-acorn-import-assertions@^1.7.6:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz#ba2b5939ce62c238db6d93d81c9b111b29b855e9"
-  integrity sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==
-
 acorn@^8.4.1, acorn@^8.5.0:
   version "8.8.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.8.0.tgz#88c0187620435c7f6015803f5539dae05a9dbea8"
@@ -905,7 +900,7 @@ emoji-regex@^8.0.0:
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
 
-enhanced-resolve@^5.8.3:
+enhanced-resolve@^5.8.0:
   version "5.10.0"
   resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.10.0.tgz#0dc579c3bb2a1032e357ac45b8f3a6f3ad4fb1e6"
   integrity sha512-T0yTFjdpldGY8PmuXXR0PyQ1ufZpEGiHVrp7zHKB7jdR4qlmZHhONVM5AQOAWXuF/w3dnHbEQVrNptJgt7F+cQ==
@@ -913,10 +908,10 @@ enhanced-resolve@^5.8.3:
     graceful-fs "^4.2.4"
     tapable "^2.2.0"
 
-es-module-lexer@^0.9.0:
-  version "0.9.3"
-  resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-0.9.3.tgz#6f13db00cc38417137daf74366f535c8eb438f19"
-  integrity sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==
+es-module-lexer@^0.7.1:
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-0.7.1.tgz#c2c8e0f46f2df06274cdaf0dd3f3b33e0a0b267d"
+  integrity sha512-MgtWFl5No+4S3TmhDmCz2ObFGm6lEpTnzbQi+Dd+pw4mlTIZTmM2iAs5gRlmx5zS9luzobCSBSI90JM/1/JgOw==
 
 escalade@^3.1.1:
   version "3.1.1"
@@ -2599,6 +2594,11 @@ snapdragon@^0.8.1:
     source-map-resolve "^0.5.0"
     use "^3.1.0"
 
+source-list-map@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.1.tgz#3993bd873bfc48479cca9ea3a547835c7c154b34"
+  integrity sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==
+
 source-map-js@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
@@ -2633,7 +2633,7 @@ source-map@^0.5.6:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
   integrity sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==
 
-source-map@^0.6.0:
+source-map@^0.6.0, source-map@^0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
@@ -2843,7 +2843,7 @@ util-deprecate@~1.0.1:
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
 
-watchpack@^2.3.0:
+watchpack@^2.2.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-2.4.0.tgz#fa33032374962c78113f93c7f2fb4c54c9862a5d"
   integrity sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==
@@ -2859,13 +2859,16 @@ webpack-merge@^5.8.0:
     clone-deep "^4.0.1"
     wildcard "^2.0.0"
 
-webpack-sources@^3.2.2:
-  version "3.2.3"
-  resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-3.2.3.tgz#2d4daab8451fd4b240cc27055ff6a0c2ccea0cde"
-  integrity sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==
+webpack-sources@^2.3.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-2.3.1.tgz#570de0af163949fe272233c2cefe1b56f74511fd"
+  integrity sha512-y9EI9AO42JjEcrTJFOYmVywVZdKVUfOvDUPsJea5GIr1JOEGFVqwlY2K098fFoIjOkDzHn2AjRvM8dsBZu+gCA==
+  dependencies:
+    source-list-map "^2.0.1"
+    source-map "^0.6.1"
 
 webpack@5.72.1, "webpack@file:../node_modules/webpack":
-  version "5.64.4"
+  version "5.45.1"
   dependencies:
     "@types/eslint-scope" "^3.7.0"
     "@types/estree" "^0.0.50"
@@ -2873,11 +2876,10 @@ webpack@5.72.1, "webpack@file:../node_modules/webpack":
     "@webassemblyjs/wasm-edit" "1.11.1"
     "@webassemblyjs/wasm-parser" "1.11.1"
     acorn "^8.4.1"
-    acorn-import-assertions "^1.7.6"
     browserslist "^4.14.5"
     chrome-trace-event "^1.0.2"
-    enhanced-resolve "^5.8.3"
-    es-module-lexer "^0.9.0"
+    enhanced-resolve "^5.8.0"
+    es-module-lexer "^0.7.1"
     eslint-scope "5.1.1"
     events "^3.2.0"
     glob-to-regexp "^0.4.1"
@@ -2889,8 +2891,8 @@ webpack@5.72.1, "webpack@file:../node_modules/webpack":
     schema-utils "^3.1.0"
     tapable "^2.1.1"
     terser-webpack-plugin "^5.1.3"
-    watchpack "^2.3.0"
-    webpack-sources "^3.2.2"
+    watchpack "^2.2.0"
+    webpack-sources "^2.3.0"
 
 wildcard@^2.0.0:
   version "2.0.0"

--- a/node-plugin/streaming/LoadFileChunkLoadingRuntimeModule.js
+++ b/node-plugin/streaming/LoadFileChunkLoadingRuntimeModule.js
@@ -225,6 +225,7 @@ class ReadFileChunkLoadingRuntimeModule extends RuntimeModule {
                               }, {})
                             )};`,
                             "Object.assign(global.__remote_scope__._config, remotes)",
+                            "const remoteRegistry = global.__remote_scope__._config",
                             /* TODO: keying by global should be ok, but need to verify - need to deal with when user passes promise new promise()
     global will/should still exist - but can only be known at runtime */
                             `console.log('remotes keyed by global name',remotes)`,
@@ -237,18 +238,6 @@ class ReadFileChunkLoadingRuntimeModule extends RuntimeModule {
                               name
                             )}])`,
 
-                            `if(global.REMOTE_CONFIG && !global.REMOTE_CONFIG[${JSON.stringify(
-                              name
-                            )}]) {
-                  if(global.loadedRemotes){
-                    for (const property in global.loadedRemotes) {
-                      global.REMOTE_CONFIG[property] = global.loadedRemotes[property].path
-                    }
-                  }`,
-                            Template.indent([
-                              `Object.assign(global.REMOTE_CONFIG, remotes)`,
-                            ]),
-                            '}',
                             /*   TODO: this global.REMOTE_CONFIG doesnt work in this v5 core, not sure if i need to keep it or not
                                  not deleting it yet since i might need this for tracking all the remote entries across systems
                                  for now, im going to use locally known remote scope from remoteEntry config
@@ -260,9 +249,7 @@ class ReadFileChunkLoadingRuntimeModule extends RuntimeModule {
                                 )}]`,
                              */
                             "console.log('about to derive remote making request')",
-                            /*TODO: remotes variable will not work in many cases for looking up remotes own url, see note above
-                                    this only works becuase the demo lists all remotes and all remotes happen to be same url and version */
-                            `var requestedRemote = remotes[${JSON.stringify(
+                            `var requestedRemote = remoteRegistry[${JSON.stringify(
                               name
                             )}]`,
                             "console.log('requested remote', requestedRemote)",
@@ -285,8 +272,6 @@ class ReadFileChunkLoadingRuntimeModule extends RuntimeModule {
                             `var scriptUrl = new URL(requestedRemote);`,
 
                             `var chunkName = ${RuntimeGlobals.getChunkScriptFilename}(chunkId);`,
-
-                            // `console.log('remotes global',global.REMOTE_CONFIG);`,
 
                             `console.log('chunkname to request',chunkName);`,
                             `var fileToReplace = require('path').basename(scriptUrl.pathname);`,

--- a/node-plugin/streaming/LoadFileChunkLoadingRuntimeModule.js
+++ b/node-plugin/streaming/LoadFileChunkLoadingRuntimeModule.js
@@ -224,9 +224,11 @@ class ReadFileChunkLoadingRuntimeModule extends RuntimeModule {
                                 return acc;
                               }, {})
                             )};`,
+                            "Object.assign(global.__remote_scope__._config, remotes)",
                             /* TODO: keying by global should be ok, but need to verify - need to deal with when user passes promise new promise()
     global will/should still exist - but can only be known at runtime */
                             `console.log('remotes keyed by global name',remotes)`,
+                            `console.log('remote scope configs',global.__remote_scope__._config)`,
 
                             `console.log('global.__remote_scope__',global.__remote_scope__)`,
                             `console.log('global.__remote_scope__[${JSON.stringify(

--- a/node-plugin/streaming/NodeRuntime.js
+++ b/node-plugin/streaming/NodeRuntime.js
@@ -77,7 +77,9 @@ function buildRemotes(mfConf, webpack) {
       const loadTemplate = `promise new Promise((resolve)=>{
     if(!global.__remote_scope__) {
       // create a global scope for container, similar to how remotes are set on window in the browser
-      global.__remote_scope__ = {}
+      global.__remote_scope__ = {
+        _config: {},
+      }
     }
     ${executeLoadTemplate}
     resolve(executeLoad(${JSON.stringify(config)}))

--- a/node-plugin/streaming/NodeRuntime.js
+++ b/node-plugin/streaming/NodeRuntime.js
@@ -79,6 +79,7 @@ function buildRemotes(mfConf, webpack) {
   TODO: global remote scope object should go into webpack runtime as a runtime requirement
    this can be done by referencing my LoadFile, CommonJs plugins in this directory.
   */
+      const [global, url] = config.split('@');
       const loadTemplate = `promise new Promise((resolve)=>{
     if(!global.__remote_scope__) {
       // create a global scope for container, similar to how remotes are set on window in the browser
@@ -86,6 +87,9 @@ function buildRemotes(mfConf, webpack) {
         _config: {},
       }
     }
+    
+    global.__remote_scope__._config[${JSON.stringify(global)}] = ${JSON.stringify(url)};
+ 
     ${executeLoadTemplate}
     resolve(executeLoad(${JSON.stringify(config)}))
     }).then(remote=>{


### PR DESCRIPTION
Remotes typically do not know their own URL;

home usually wont have itself listed as a remote, but shop would have home as a remote. 
When loading home, the container needs a way to know its absolute URL path in order to load the federated module chunks. 

To do so, we want each host/remote to register all its @ syntax configs to a global object - this way, a remote can look itself up by name and find the URL from its parent. 

Since versioned remotes is possible, we want to look up by global name, there should only ever be one global or a URL just like in the browser. So this is a safe operation as collisions here would be the same as collisions in the browser.

https://youtu.be/cQawWpUl8ro