### PR TITLE
fix(MFClient): correctly handle routeInfo loading errors

### DIFF
--- a/demo/3000-home/pages/_menu.js
+++ b/demo/3000-home/pages/_menu.js
@@ -4,6 +4,7 @@ import { Menu } from 'antd';
 const menuItems = [
   { label: 'Main home', key: '/' },
   { label: 'Test hook from remote', key: '/home/test-remote-hook' },
+  { label: 'Test broken remotes', key: '/home/test-broken-remotes' },
   { label: 'Exposed pages', key: '/home/exposed-pages' },
   {
     label: 'Exposed components',

--- a/demo/3000-home/pages/home/test-broken-remotes.js
+++ b/demo/3000-home/pages/home/test-broken-remotes.js
@@ -1,0 +1,25 @@
+import Link from 'next/link';
+
+export default function TestBrokenRemotes() {
+  return (
+    <div>
+      <h2>This page is a test for broken remoteEntries.js</h2>
+
+      <p>
+        Check unresolved host –{' '}
+        <Link href="/unresolved-host">
+          <a>/unresolved-host</a>
+        </Link>{' '}
+        (on http://localhost:<b>3333</b>/_next/static/chunks/remoteEntry.js)
+      </p>
+      <p>
+        Check wrong response for remoteEntry –{' '}
+        <Link href="/wrong-entry">
+          <a>/wrong-entry</a>
+        </Link>{' '}
+        (on http://localhost:3000/_next/static/chunks/remoteEntry<b>Wrong</b>
+        .js)
+      </p>
+    </div>
+  );
+}

--- a/demo/mfRoutes.js
+++ b/demo/mfRoutes.js
@@ -11,4 +11,10 @@ module.exports = {
     '/checkout',
     '/checkout/exposed-pages',
   ],
+  'unresolvedHost@http://localhost:3333/_next/static/chunks/remoteEntry.js': [
+    '/unresolved-host',
+  ],
+  'wrongEntry@http://localhost:3000/_next/static/chunks/remoteEntryWrong.js': [
+    '/wrong-entry',
+  ],
 };

--- a/src/loaders/patchNextClientPageLoader.js
+++ b/src/loaders/patchNextClientPageLoader.js
@@ -32,7 +32,7 @@ function patchNextClientPageLoader(content) {
       class PageLoaderExtended extends PageLoader {
         constructor(buildId, assetPrefix) {
           super(buildId, assetPrefix);
-          global.mf_client = new MFClient(this);
+          global.mf_client = new MFClient(this, { mode: process.env.NODE_ENV });
         }
 
         _getPageListOriginal() {


### PR DESCRIPTION
If remoteEntry or module are unavailable then reload a page and try to get its server version.

I have 20 nextjs apps and I met with a migration issue. I cannot update all applications instantly. So if one of the application does not expose remoteEntry then we need just to reload the page and the Load balancer will serve the correct application. Like it works now with NextJS [Multi Zones](https://nextjs.org/docs/advanced-features/multi-zones).

With this fix, I will be able to migrate and update applications separately. And some transitions between apps will be with page reloads others without.

-----

### In DEV mode I will see the following page (no need to reload page from server):

<img width="1051" alt="Screen Shot 2022-09-17 at 02 35 44" src="https://user-images.githubusercontent.com/1946920/190729214-67aec758-814b-4de2-9abc-21b5ef99f148.png">


### But in PRODUCTION it will reload the page trying to get the server version. In this case, the server returns a 404 page because the page really does not exist

<img width="1181" alt="Screen Shot 2022-09-17 at 02 23 28" src="https://user-images.githubusercontent.com/1946920/190729329-2f184294-e63f-4953-a021-ef562b3db2a2.png">


