### PR TITLE
Custom promises from userland

### DIFF
--- a/demo/3000-home/next.config.js
+++ b/demo/3000-home/next.config.js
@@ -1,20 +1,31 @@
 const NextFederationPlugin = require('@module-federation/nextjs-mf');
-
+const {customPromise} = require('@module-federation/nextjs-mf/lib/utils')
+const Template = require('webpack').Template
+console.log(NextFederationPlugin);
 module.exports = {
   webpack(config, options) {
     const { isServer } = options;
     if (!options.isServer) {
+      const remotes = {
+        shop: `shop@http://localhost:3001/_next/static/${
+          isServer ? 'ssr' : 'chunks'
+        }/remoteEntry.js`,
+        checkout: `checkout@http://localhost:3002/_next/static/${
+          isServer ? 'ssr' : 'chunks'
+        }/remoteEntry.js`,
+      }
       config.plugins.push(
         new NextFederationPlugin({
           name: 'home_app',
           filename: 'static/chunks/remoteEntry.js',
           remotes: {
-            shop: `shop@http://localhost:3001/_next/static/${
-              isServer ? 'ssr' : 'chunks'
-            }/remoteEntry.js`,
-            checkout: `checkout@http://localhost:3002/_next/static/${
-              isServer ? 'ssr' : 'chunks'
-            }/remoteEntry.js`,
+            shop: customPromise(remotes.shop,Template, function() { new Promise((resolve, reject) => {
+              console.log('runing other promise');
+              setTimeout(() => {
+                resolve('shop');
+              } , 1000);
+            })}),
+            checkout: customPromise(remotes.checkout, Template),
           },
           exposes: {
             './SharedNav': './components/SharedNav.js',

--- a/demo/3000-home/next.config.js
+++ b/demo/3000-home/next.config.js
@@ -1,7 +1,5 @@
 const NextFederationPlugin = require('@module-federation/nextjs-mf');
-const {customPromise} = require('@module-federation/nextjs-mf/lib/utils')
-const Template = require('webpack').Template
-console.log(NextFederationPlugin);
+const {promiseTemplate} = require('@module-federation/nextjs-mf/lib/build-utils');
 module.exports = {
   webpack(config, options) {
     const { isServer } = options;
@@ -19,13 +17,13 @@ module.exports = {
           name: 'home_app',
           filename: 'static/chunks/remoteEntry.js',
           remotes: {
-            shop: customPromise(remotes.shop,Template, function() { new Promise((resolve, reject) => {
+            shop: promiseTemplate(remotes.shop, function() { new Promise((resolve, reject) => {
               console.log('runing other promise');
               setTimeout(() => {
                 resolve('shop');
               } , 1000);
             })}),
-            checkout: customPromise(remotes.checkout, Template),
+            checkout: promiseTemplate(remotes.checkout),
           },
           exposes: {
             './SharedNav': './components/SharedNav.js',

--- a/demo/3000-home/next.config.js
+++ b/demo/3000-home/next.config.js
@@ -1,5 +1,6 @@
 const NextFederationPlugin = require('@module-federation/nextjs-mf');
 const {promiseTemplate, promiseFactory} = require('@module-federation/nextjs-mf/lib/build-utils');
+
 module.exports = {
   webpack(config, options) {
     const { isServer } = options;
@@ -17,14 +18,18 @@ module.exports = {
           name: 'home_app',
           filename: 'static/chunks/remoteEntry.js',
           remotes: {
-            shop: promiseTemplate(remotes.shop, promiseFactory(function(resolve,reject){
+            shop: promiseTemplate(
+              promiseFactory((resolve, reject) => {
+                resolve('shop@http://localhost:3001/_next/static/chunks/remoteEntry.js');
+              }),
+              promiseFactory((resolve,reject)=>{
               console.log('runing other promise');
               setTimeout(() => {
                 console.log('resolving promise');
                 resolve();
               } , 1000);
             })),
-            checkout: promiseTemplate(remotes.checkout),
+            checkout: remotes.checkout,
           },
           exposes: {
             './SharedNav': './components/SharedNav.js',

--- a/demo/3000-home/next.config.js
+++ b/demo/3000-home/next.config.js
@@ -18,18 +18,7 @@ module.exports = {
           name: 'home_app',
           filename: 'static/chunks/remoteEntry.js',
           remotes: {
-            shop: promiseTemplate(
-              // can also be a string if it needs to be computed in scope
-              `(resolve, reject) => {
-                resolve("${remotes.shop}");
-              }`,
-              (resolve,reject)=>{
-              console.log('runing other promise');
-              setTimeout(() => {
-                console.log('resolving promise');
-                resolve();
-              } , 1000);
-            }),
+            shop: remotes.shop,
             checkout: remotes.checkout,
           },
           exposes: {

--- a/demo/3000-home/next.config.js
+++ b/demo/3000-home/next.config.js
@@ -1,5 +1,5 @@
 const NextFederationPlugin = require('@module-federation/nextjs-mf');
-const {promiseTemplate} = require('@module-federation/nextjs-mf/lib/build-utils');
+const {promiseTemplate, promiseFactory} = require('@module-federation/nextjs-mf/lib/build-utils');
 module.exports = {
   webpack(config, options) {
     const { isServer } = options;
@@ -17,12 +17,13 @@ module.exports = {
           name: 'home_app',
           filename: 'static/chunks/remoteEntry.js',
           remotes: {
-            shop: promiseTemplate(remotes.shop, function() { new Promise((resolve, reject) => {
+            shop: promiseTemplate(remotes.shop, promiseFactory(function(resolve,reject){
               console.log('runing other promise');
               setTimeout(() => {
-                resolve('shop');
+                console.log('resolving promise');
+                resolve();
               } , 1000);
-            })}),
+            })),
             checkout: promiseTemplate(remotes.checkout),
           },
           exposes: {

--- a/demo/3000-home/next.config.js
+++ b/demo/3000-home/next.config.js
@@ -20,7 +20,7 @@ module.exports = {
           remotes: {
             shop: promiseTemplate(
               promiseFactory((resolve, reject) => {
-                resolve('shop@http://localhost:3001/_next/static/chunks/remoteEntry.js');
+                resolve(remotes.shop);
               }),
               promiseFactory((resolve,reject)=>{
               console.log('runing other promise');

--- a/demo/3000-home/next.config.js
+++ b/demo/3000-home/next.config.js
@@ -19,16 +19,17 @@ module.exports = {
           filename: 'static/chunks/remoteEntry.js',
           remotes: {
             shop: promiseTemplate(
-              promiseFactory((resolve, reject) => {
-                resolve(remotes.shop);
-              }),
-              promiseFactory((resolve,reject)=>{
+              // can also be a string if it needs to be computed in scope
+              `(resolve, reject) => {
+                resolve("${remotes.shop}");
+              }`,
+              (resolve,reject)=>{
               console.log('runing other promise');
               setTimeout(() => {
                 console.log('resolving promise');
                 resolve();
               } , 1000);
-            })),
+            }),
             checkout: remotes.checkout,
           },
           exposes: {

--- a/demo/3001-shop/next.config.js
+++ b/demo/3001-shop/next.config.js
@@ -1,4 +1,4 @@
-const NextFederationPlugin = require('@module-federation/nextjs-mf/lib/NextFederationPlugin');
+const NextFederationPlugin = require('@module-federation/nextjs-mf');
 
 module.exports = {
   swcMinify: true,

--- a/demo/3001-shop/pages/shop/index.js
+++ b/demo/3001-shop/pages/shop/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import Head from 'next/head';
 import WebpackPng from '../../components/WebpackPng';
-console.log('nested remote',import('home/SharedNav'))
+// console.log('nested remote',import('home/SharedNav'))
 
 const Shop = () => (
   <div>

--- a/demo/package.json
+++ b/demo/package.json
@@ -11,7 +11,7 @@
     "dev": "concurrently -n _,home,shop,checkout \"yarn sync-pkg -w\" \"cd 3000-home; npm run dev\" \"cd 3001-shop; npm run dev\" \"cd 3002-checkout; npm run dev\"",
     "build": "yarn sync-pkg && concurrently -n home,shop,checkout \"cd 3000-home; npm run build\" \"cd 3001-shop; npm run build\" \"cd 3002-checkout; npm run build\"",
     "start": "yarn sync-pkg && concurrently -n home,shop,checkout \"cd 3000-home; npm run start\" \"cd 3001-shop; npm run start\" \"cd 3002-checkout; npm run start\"",
-    "sync-pkg": "cpx \"../lib/**\" ./tmp/nextjs-mf/lib && cd ./tmp/nextjs-mf/lib"
+    "sync-pkg": "cpx \"../lib/**\" ./tmp/nextjs-mf/lib"
   },
   "dependencies": {
     "concurrently": "^7.0.0",

--- a/demo/package.json
+++ b/demo/package.json
@@ -15,7 +15,8 @@
   },
   "dependencies": {
     "concurrently": "^7.0.0",
-    "cpx": "1.5.0"
+    "cpx": "1.5.0",
+    "webpack-sources": "^3.2.0"
   },
   "resolutions": {
     "@module-federation/nextjs-mf": "link:./tmp/nextjs-mf",

--- a/demo/package.json
+++ b/demo/package.json
@@ -11,12 +11,11 @@
     "dev": "concurrently -n _,home,shop,checkout \"yarn sync-pkg -w\" \"cd 3000-home; npm run dev\" \"cd 3001-shop; npm run dev\" \"cd 3002-checkout; npm run dev\"",
     "build": "yarn sync-pkg && concurrently -n home,shop,checkout \"cd 3000-home; npm run build\" \"cd 3001-shop; npm run build\" \"cd 3002-checkout; npm run build\"",
     "start": "yarn sync-pkg && concurrently -n home,shop,checkout \"cd 3000-home; npm run start\" \"cd 3001-shop; npm run start\" \"cd 3002-checkout; npm run start\"",
-    "sync-pkg": "cpx \"../lib/**\" ./tmp/nextjs-mf/lib"
+    "sync-pkg": "cpx \"../lib/**\" ./tmp/nextjs-mf/lib && cd ./tmp/nextjs-mf/lib"
   },
   "dependencies": {
     "concurrently": "^7.0.0",
-    "cpx": "1.5.0",
-    "webpack-sources": "^3.2.0"
+    "cpx": "1.5.0"
   },
   "resolutions": {
     "@module-federation/nextjs-mf": "link:./tmp/nextjs-mf",

--- a/demo/tmp/nextjs-mf/package.json
+++ b/demo/tmp/nextjs-mf/package.json
@@ -1,35 +1,52 @@
 {
   "public": true,
   "name": "@module-federation/nextjs-mf",
-  "version": "5.2.1",
+  "version": "5.4.0",
   "description": "Module Federation helper for NextJS",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "repository": "https://github.com/module-federation/nextjs-mf",
   "author": "Zack Jackson <zackary.l.jackson@gmail.com>",
+  "contributors": [
+    "Pavel Chertorogov, nodkz <pavel.chertorogov@gmail.com> (www.ps.kz)"
+  ],
   "license": "MIT",
   "scripts": {
-    "prepare": "yarn build",
-    "demo": "yarn build && cd demo && yarn sync-pkg && yarn --force && yarn dev",
-    "debug": "yarn build && cd demo; yarn sync-pkg && yarn --force && yarn build && yarn serve",
+    "demo": "sleep 3 && cd demo && yarn install && yarn dev",
+    "dev": "rm -rf lib && concurrently \"yarn sync-files --watch\" \"yarn compile --watch\" \"yarn demo\"",
     "prettier": "prettier --write \"**/*.{js,json,md,ts,tsx}\"",
-    "build": "rm -rf lib && cp -r ./src/ lib/ && rollup -c",
+    "sync-files": "cpx \"src/**/*.js\" lib/",
+    "compile": "rollup -c",
+    "build": "rm -rf lib && yarn sync-files && yarn compile",
     "prepublishOnly": "yarn build"
   },
   "dependencies": {
     "chalk": "^4.0.0",
-    "fast-glob": "^3.2.11"
+    "eventemitter3": "^4.0.7",
+    "fast-glob": "^3.2.11",
+    "webpack-sources": "^3.2.3"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^22.0.2",
     "@rollup/plugin-multi-entry": "^4.1.0",
     "@rollup/plugin-node-resolve": "^13.3.0",
+    "@types/react": "^18.0.19",
+    "concurrently": "^7.3.0",
+    "cpx": "^1.5.0",
     "next": "12.3.0",
     "prettier": "2.3.2",
+    "react": "^18.2.0",
     "rollup": "^2.78.1",
     "rollup-obfuscator": "^3.0.1",
     "rollup-plugin-node-builtins": "^2.1.2",
     "rollup-plugin-node-globals": "^1.4.0",
+    "rollup-plugin-rename-node-modules": "^1.3.1",
+    "rollup-plugin-typescript2": "0.34.0",
+    "tslib": "^2.4.0",
+    "typescript": "^4.8.2",
     "webpack": "5.64.4"
+  },
+  "peerDependencies": {
+    "react": "^17.0.0 || ^18.0.0"
   }
 }

--- a/demo/yarn.lock
+++ b/demo/yarn.lock
@@ -2856,8 +2856,10 @@ webpack-merge@^5.8.0:
     clone-deep "^4.0.1"
     wildcard "^2.0.0"
 
-webpack-sources@^3.2.0, webpack-sources@^3.2.2, webpack-sources@^3.2.3, "webpack-sources@file:../node_modules/webpack-sources":
+webpack-sources@^3.2.2, webpack-sources@^3.2.3:
   version "3.2.3"
+  resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-3.2.3.tgz#2d4daab8451fd4b240cc27055ff6a0c2ccea0cde"
+  integrity sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==
 
 webpack@5.72.1, "webpack@file:../node_modules/webpack":
   version "5.64.4"

--- a/demo/yarn.lock
+++ b/demo/yarn.lock
@@ -946,6 +946,11 @@ estraverse@^5.2.0:
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.3.0.tgz#2eea5290702f26ab8fe5370370ff86c965d21123"
   integrity sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==
 
+eventemitter3@^4.0.7:
+  version "4.0.7"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
+  integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
+
 events@^3.2.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
@@ -2851,10 +2856,8 @@ webpack-merge@^5.8.0:
     clone-deep "^4.0.1"
     wildcard "^2.0.0"
 
-webpack-sources@^3.2.2:
+webpack-sources@^3.2.0, webpack-sources@^3.2.2, webpack-sources@^3.2.3, "webpack-sources@file:../node_modules/webpack-sources":
   version "3.2.3"
-  resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-3.2.3.tgz#2d4daab8451fd4b240cc27055ff6a0c2ccea0cde"
-  integrity sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==
 
 webpack@5.72.1, "webpack@file:../node_modules/webpack":
   version "5.64.4"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   "dependencies": {
     "chalk": "^4.0.0",
     "eventemitter3": "^4.0.7",
-    "fast-glob": "^3.2.11"
+    "fast-glob": "^3.2.11",
+    "webpack-sources": "^3.2.3"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^22.0.2",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "prepublishOnly": "yarn build"
   },
   "dependencies": {
+    "@swc/core": "^1.3.2",
     "chalk": "^4.0.0",
     "eventemitter3": "^4.0.7",
     "fast-glob": "^3.2.11",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -52,6 +52,7 @@ export default [
       './src/utils.js',
       './src/internal.js',
       './src/build-utils.js',
+      './src/loaders/fixImageLoader.js',
     ],
     output: {
       dir: 'lib',
@@ -68,6 +69,7 @@ export default [
       'next',
       'fast-glob',
       'webpack-sources',
+      /!webpack\/lib\/Template/,
     ], // tells Rollup 'I know what I'm doing here'
     plugins: [
       renameNodeModules('dependencies'),

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -50,7 +50,7 @@ export default [
       dir: 'lib',
       format: 'cjs',
       preserveModules: true,
-      exports: 'auto',
+      exports: 'named',
       preserveModulesRoot: 'src',
     },
     treeshake: false,
@@ -60,7 +60,7 @@ export default [
       'crypto',
       'next',
       'fast-glob',
-      /node_modules\/(?!webpack)/,
+      /webpack-sources/,
     ], // tells Rollup 'I know what I'm doing here'
     plugins: [
       renameNodeModules('dependencies'),

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -37,6 +37,12 @@ export default [
         inlineSources: !production,
       }),
       commonjs(),
+      globals({
+        dirname: false,
+        filename: false,
+        process: false,
+        global: false,
+      }),
       renameNodeModules('dependencies'),
     ],
   },
@@ -45,6 +51,7 @@ export default [
       './src/NextFederationPlugin.js',
       './src/utils.js',
       './src/internal.js',
+      './src/build-utils.js',
     ],
     output: {
       dir: 'lib',
@@ -60,7 +67,7 @@ export default [
       'crypto',
       'next',
       'fast-glob',
-      /webpack-sources/,
+      'webpack-sources',
     ], // tells Rollup 'I know what I'm doing here'
     plugins: [
       renameNodeModules('dependencies'),
@@ -71,6 +78,7 @@ export default [
         filename: false,
         process: false,
         fs: false,
+        global: false,
       }),
       builtins(),
     ],

--- a/src/NextFederationPlugin.js
+++ b/src/NextFederationPlugin.js
@@ -6,13 +6,13 @@
 
 import fs from 'fs';
 import path from 'path';
-const {
+import {
   injectRuleLoader,
   hasLoader,
   toDisplayErrors,
-} = require('./loaders/helpers');
-const { exposeNextjsPages } = require('./loaders/nextPageMapLoader');
-const DevHmrFixInvalidPongPlugin = require('./plugins/DevHmrFixInvalidPongPlugin');
+} from './loaders/helpers'
+import { exposeNextjsPages } from './loaders/nextPageMapLoader'
+import DevHmrFixInvalidPongPlugin from './plugins/DevHmrFixInvalidPongPlugin'
 
 import {
   reKeyHostShared,
@@ -22,7 +22,8 @@ import {
   internalizeSharedPackages,
   getOutputPath,
   externalizedShares,
-  removePlugins
+  removePlugins,
+  parseRemotes
 } from './internal';
 import StreamingTargetPlugin from '../node-plugin/streaming';
 import NodeFederationPlugin from '../node-plugin/streaming/NodeRuntime';
@@ -461,19 +462,7 @@ class NextFederationPlugin {
         });
       }
       if (this._options.remotes) {
-        const parsedRemotes = Object.entries(this._options.remotes).reduce(
-          (acc, remote) => {
-            if (remote[1].includes('@')) {
-              const [url, global] = extractUrlAndGlobal(remote[1]);
-              acc[remote[0]] = generateRemoteTemplate(url, global);
-              return acc;
-            }
-            acc[remote[0]] = remote[1];
-            return acc;
-          },
-          {}
-        );
-        this._options.remotes = parsedRemotes;
+        this._options.remotes = parseRemotes(this._options.remotes)
       }
       if (this._options.library) {
         console.error('[mf] you cannot set custom library');
@@ -487,7 +476,8 @@ class NextFederationPlugin {
     //todo runtime variable creation needs to be applied for server as well. this is just for client
     // todo: this needs to be refactored into something more comprehensive. this is just a quick fix
     new webpack.DefinePlugin({
-      'process.env.REMOTES': createRuntimeVariables(this._options.remotes),
+      'process.env.REMOTES': {
+  },
       'process.env.CURRENT_HOST': JSON.stringify(this._options.name),
     }).apply(compiler);
 
@@ -527,4 +517,4 @@ class NextFederationPlugin {
   }
 }
 
-module.exports = NextFederationPlugin;
+export default NextFederationPlugin;

--- a/src/NextFederationPlugin.js
+++ b/src/NextFederationPlugin.js
@@ -17,14 +17,13 @@ import DevHmrFixInvalidPongPlugin from './plugins/DevHmrFixInvalidPongPlugin'
 import {
   reKeyHostShared,
   DEFAULT_SHARE_SCOPE,
-  generateRemoteTemplate,
   internalizeSharedPackages,
   getOutputPath,
   externalizedShares,
   removePlugins,
   parseRemotes
 } from './internal';
-import {extractUrlAndGlobal} from './utils'
+
 import ChildFriendlyModuleFederationPlugin from './ModuleFederationPlugin';
 
 const CHILD_PLUGIN_NAME = 'ChildFederationPlugin';

--- a/src/NextFederationPlugin.js
+++ b/src/NextFederationPlugin.js
@@ -25,8 +25,6 @@ import {
   parseRemotes
 } from './internal';
 import {extractUrlAndGlobal} from './utils'
-import StreamingTargetPlugin from '../node-plugin/streaming';
-import NodeFederationPlugin from '../node-plugin/streaming/NodeRuntime';
 import ChildFriendlyModuleFederationPlugin from './ModuleFederationPlugin';
 
 const CHILD_PLUGIN_NAME = 'ChildFederationPlugin';
@@ -169,6 +167,9 @@ class ChildFederationPlugin {
           new AddRuntimeRequirementToPromiseExternal(),
         ];
       } else if (compiler.options.name === 'server') {
+        const StreamingTargetPlugin = require('../node-plugin/streaming').default;
+        const NodeFederationPlugin = require('../node-plugin/streaming/NodeRuntime').default;
+
         plugins = [
           new NodeFederationPlugin(federationPluginOptions, {ModuleFederationPlugin: FederationPlugin}),
           new webpack.node.NodeTemplatePlugin(childOutput),
@@ -442,6 +443,7 @@ class NextFederationPlugin {
       console.error('[nextjs-mf] WARNING: SSR IS NOT FULLY SUPPORTED YET, Only use pluign on client builds');
       // target false because we use our own target for node env
       compiler.options.target = false;
+      const StreamingTargetPlugin = require('../node-plugin/streaming').default;
       new StreamingTargetPlugin(this._options, webpack).apply(compiler);
       this._options.library = {};
       this._options.library.type = 'commonjs-module';
@@ -480,11 +482,8 @@ class NextFederationPlugin {
       'process.env.CURRENT_HOST': JSON.stringify(this._options.name),
     }).apply(compiler);
 
+    const ModuleFederationPlugin = isServer ? require('../node-plugin/streaming/NodeRuntime').default : webpack.container.ModuleFederationPlugin;
 
-    const ModuleFederationPlugin = {
-      client: webpack.container.ModuleFederationPlugin,
-      server: NodeFederationPlugin,
-    }[compiler.options.name];
     // ignore edge runtime and middleware builds
     if (ModuleFederationPlugin) {
       const internalShare = reKeyHostShared(this._options.shared);

--- a/src/NextFederationPlugin.js
+++ b/src/NextFederationPlugin.js
@@ -476,8 +476,7 @@ class NextFederationPlugin {
     //todo runtime variable creation needs to be applied for server as well. this is just for client
     // todo: this needs to be refactored into something more comprehensive. this is just a quick fix
     new webpack.DefinePlugin({
-      'process.env.REMOTES': {
-  },
+      'process.env.REMOTES': createRuntimeVariables(this._options.remotes),
       'process.env.CURRENT_HOST': JSON.stringify(this._options.name),
     }).apply(compiler);
 

--- a/src/NextFederationPlugin.js
+++ b/src/NextFederationPlugin.js
@@ -17,7 +17,6 @@ import DevHmrFixInvalidPongPlugin from './plugins/DevHmrFixInvalidPongPlugin'
 import {
   reKeyHostShared,
   DEFAULT_SHARE_SCOPE,
-  extractUrlAndGlobal,
   generateRemoteTemplate,
   internalizeSharedPackages,
   getOutputPath,
@@ -25,6 +24,7 @@ import {
   removePlugins,
   parseRemotes
 } from './internal';
+import {extractUrlAndGlobal} from './utils'
 import StreamingTargetPlugin from '../node-plugin/streaming';
 import NodeFederationPlugin from '../node-plugin/streaming/NodeRuntime';
 import ChildFriendlyModuleFederationPlugin from './ModuleFederationPlugin';

--- a/src/NextFederationPlugin.js
+++ b/src/NextFederationPlugin.js
@@ -462,6 +462,7 @@ class NextFederationPlugin {
           loader: path.resolve(__dirname, './loaders/patchNextClientPageLoader'),
         });
       }
+
       if (this._options.remotes) {
         this._options.remotes = parseRemotes(this._options.remotes)
       }

--- a/src/build-utils.js
+++ b/src/build-utils.js
@@ -1,21 +1,122 @@
 import {parseRemoteSyntax} from "./internal";
+import {extractUrlAndGlobal} from "./utils";
 import Template from 'webpack/lib/Template';
-export const promiseTemplate = (remote,...otherPromises) => {
+
+const swc = require("@swc/core");
+
+const transformInput = (code) => {
+  return swc.transformSync(code, {
+    // Some options cannot be specified in .swcrc
+    sourceMaps: false,
+    // Input files are treated as module by default.
+    isModule: false,
+    // All options below can be configured via .swcrc
+    jsc: {
+      "loose": false,
+      target: "es5",
+      "externalHelpers": false,
+      parser: {
+        syntax: "ecmascript",
+      },
+      transform: {},
+    },
+  }).code
+}
+
+
+const remoteTemplate = function() {
+    const index = urlAndGlobal.indexOf('@');
+    if (index <= 0 || index === urlAndGlobal.length - 1) {
+      throw new Error(`Invalid request "${urlAndGlobal}"`);
+    }
+    var remote = {url: urlAndGlobal.substring(index + 1), global: urlAndGlobal.substring(0, index)}
+    return new Promise(function (resolve, reject) {
+      var __webpack_error__ = new Error();
+      if (typeof window[remote.global] !== 'undefined') {
+        return resolve();
+      }
+      __webpack_require__.l(remote.url, function (event) {
+        if (typeof window[remote.global] !== 'undefined') {
+          return resolve();
+        }
+
+        var errorType = event && (event.type === 'load' ? 'missing' : event.type);
+        var realSrc = event && event.target && event.target.src;
+        __webpack_error__.message = 'Loading script failed.(' + errorType + ': ' + realSrc + ' or global var ' + remote.global + ')';
+        __webpack_error__.name = 'ScriptExternalLoadError';
+        __webpack_error__.type = errorType;
+        __webpack_error__.request = realSrc;
+        reject(__webpack_error__);
+      }, remote.global);
+    }).then(function () {
+      const proxy = {
+        get: window[remote.global].get,
+        init: function (shareScope) {
+          const handler = {
+            get(target, prop) {
+              if (target[prop]) {
+                Object.values(target[prop]).forEach(function (o) {
+                  if (o.from === '_N_E') {
+                    o.loaded = 1
+                  }
+                })
+              }
+              return target[prop]
+            },
+            set(target, property, value, receiver) {
+              if (target[property]) {
+                return target[property]
+              }
+              target[property] = value
+              return true
+            }
+          }
+          try {
+            window[remote.global].init(new Proxy(shareScope, handler))
+          } catch (e) {
+
+          }
+          window[remote.global].__initialized = true
+        }
+      }
+      if (!window[remote.global].__initialized) {
+        proxy.init()
+      }
+      return proxy
+    })
+}
+
+
+export const promiseTemplate = (remote, ...otherPromises) => {
   let promises = '';
   if (otherPromises) {
     promises = otherPromises.map((p) => {
       return Template.getFunctionContent(p)
     })
   }
+  let remoteSyntax = remote
+  let remoteFactory = parseRemoteSyntax
+  if(remote.startsWith('function')) {
+    remoteSyntax = Template.getFunctionContent(remote);
+    remoteFactory = (remoteSyntax) => {
+      return Template.asString([
+        `${remoteSyntax}.then(function(urlAndGlobal) {`,
+        Template.indent([
+          Template.getFunctionContent(remoteTemplate)
+        ]),
+        '})'
+      ])
+    }
+  }
+
+
   const allPromises = [
-    parseRemoteSyntax(remote),
+    remoteFactory(remoteSyntax),
     ...promises
-  ].map((p) => {
-    return p + ',';
-  })
+  ].join(',\n')
   return Template.asString([
     'promise new Promise(function(resolve, reject) {',
-    Template.indent([
+    transformInput(Template.indent([
       'Promise.all([',
       Template.indent(allPromises),
       ']).then(function(promises) {',
@@ -23,20 +124,27 @@ export const promiseTemplate = (remote,...otherPromises) => {
         'resolve(promises[0]);',
       ]),
       '})',
-    ]),
+    ])),
     '})',
   ])
 }
 export const promiseFactory = (factory) => {
-  const template =  Template.asString([
+
+  const wrapper = `new Promise(${factory.toString()})`
+
+  if (wrapper.includes('require(', 'import(', 'import ')) {
+    throw new Error('promiseFactory does not support require, import, or import statements');
+  }
+
+  const template = Template.asString([
     'function() {',
     Template.indent([
-      'new Promise(',
-      factory.toString(),
-      ')',
-    ].join('')),
+      wrapper
+    ]),
     '}',
   ]);
 
+
   return template
+
 }

--- a/src/build-utils.js
+++ b/src/build-utils.js
@@ -27,3 +27,16 @@ export const promiseTemplate = (remote,...otherPromises) => {
     '})',
   ])
 }
+export const promiseFactory = (factory) => {
+  const template =  Template.asString([
+    'function() {',
+    Template.indent([
+      'new Promise(',
+      factory.toString(),
+      ')',
+    ].join('')),
+    '}',
+  ]);
+
+  return template
+}

--- a/src/build-utils.js
+++ b/src/build-utils.js
@@ -1,0 +1,30 @@
+import {parseRemoteSyntax} from "./internal";
+import Template from 'webpack/lib/Template';
+export const promiseTemplate = (remote,...otherPromises) => {
+  let promises = '';
+  if (otherPromises) {
+    promises = otherPromises.map((p) => {
+      return Template.getFunctionContent(p)
+    })
+  }
+  const allPromises = [
+    parseRemoteSyntax(remote),
+    ...promises
+  ].map((p) => {
+    return p + ',';
+  })
+console.log(Template)
+  return Template.asString([
+    'promise new Promise(function(resolve, reject) {',
+    Template.indent([
+      'Promise.all([',
+      Template.indent(allPromises),
+      ']).then(function(promises) {',
+      Template.indent([
+        'resolve(promises[0]);',
+      ]),
+      '})',
+    ]),
+    '})',
+  ])
+}

--- a/src/build-utils.js
+++ b/src/build-utils.js
@@ -13,7 +13,6 @@ export const promiseTemplate = (remote,...otherPromises) => {
   ].map((p) => {
     return p + ',';
   })
-console.log(Template)
   return Template.asString([
     'promise new Promise(function(resolve, reject) {',
     Template.indent([

--- a/src/build-utils.js
+++ b/src/build-utils.js
@@ -88,7 +88,6 @@ const remoteTemplate = function() {
 export const promiseFactory = (factory) => {
 
   const wrapper = `new Promise(${factory.toString()})`
-console.log(wrapper)
   if (wrapper.includes('require(', 'import(', 'import ')) {
     throw new Error('promiseFactory does not support require, import, or import statements');
   }

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,3 @@
 const NextFederationPlugin = require('./NextFederationPlugin');
 
-module.exports = NextFederationPlugin;
+module.exports = NextFederationPlugin.default;

--- a/src/internal.js
+++ b/src/internal.js
@@ -67,7 +67,6 @@ export const reKeyHostShared = (options) => {
     return acc;
   }, {});
 };
-
 // browser template to convert remote into promise new promise and use require.loadChunk to load the chunk
 export const generateRemoteTemplate = (url, global) => {
   return `new Promise(function (resolve, reject) {
@@ -242,7 +241,7 @@ export const parseRemoteSyntax = (remote) => {
 export const parseRemotes = (remotes) =>{
   return Object.entries(remotes).reduce(
     (acc, remote) => {
-      if (typeof remote[1] === 'string' && remote[1].includes('@')) {
+      if (!remote[1].startsWith('promise ') && remote[1].includes('@')) {
         acc[remote[0]] = 'promise ' + parseRemoteSyntax(remote[1])
         return acc;
       }

--- a/src/internal.js
+++ b/src/internal.js
@@ -1,5 +1,6 @@
 import { parseOptions } from 'webpack/lib/container/options';
 import { isRequiredVersion } from 'webpack/lib/sharing/utils';
+import {extractUrlAndGlobal} from "./utils";
 import path from 'path';
 
 // the share scope we attach by default
@@ -65,15 +66,6 @@ export const reKeyHostShared = (options) => {
     }
     return acc;
   }, {});
-};
-
-// split the @ syntax into url and global
-export const extractUrlAndGlobal = (urlAndGlobal) => {
-  const index = urlAndGlobal.indexOf('@');
-  if (index <= 0 || index === urlAndGlobal.length - 1) {
-    throw new Error(`Invalid request "${urlAndGlobal}"`);
-  }
-  return [urlAndGlobal.substring(index + 1), urlAndGlobal.substring(0, index)];
 };
 
 // browser template to convert remote into promise new promise and use require.loadChunk to load the chunk
@@ -259,33 +251,4 @@ export const parseRemotes = (remotes) =>{
     },
     {}
   );
-}
-
-export const customPromise = (remote,Template,...otherPromises) => {
-  let promises = '';
-  if (otherPromises) {
-    promises = otherPromises.map((p) => {
-      return Template.getFunctionContent(p)
-    })
-  }
-  const allPromises = [
-    parseRemoteSyntax(remote),
-    ...promises
-  ].map((p) => {
-    return p + ',';
-  })
-
-  return Template.asString([
-    'promise new Promise(function(resolve, reject) {',
-    Template.indent([
-      'Promise.all([',
-      Template.indent(allPromises),
-      ']).then(function(promises) {',
-      Template.indent([
-        'resolve(promises[0]);',
-      ]),
-      '})',
-    ]),
-    '})',
-  ])
 }

--- a/src/loaders/fixImageLoader.js
+++ b/src/loaders/fixImageLoader.js
@@ -1,6 +1,5 @@
-const path = require('path');
-const Template = require('webpack/lib/Template');
-const RuntimeGlobals = require('webpack/lib/RuntimeGlobals');
+import Template from 'webpack/lib/Template';
+import path from 'path';
 
 /**
  * This loader was specially created for tunning next-image-loader result
@@ -18,6 +17,7 @@ const RuntimeGlobals = require('webpack/lib/RuntimeGlobals');
  */
 async function fixImageLoader(remaining) {
   this.cacheable(true);
+  const publicPath = this._compiler.webpack.RuntimeGlobals.publicPath;
   const isServer = this._compiler.options.name !== 'client';
   const result = await this.importModule(
     `${this.resourcePath}.webpack[javascript/auto]` + `!=!${remaining}`
@@ -26,7 +26,7 @@ async function fixImageLoader(remaining) {
 
   const computedAssetPrefix = isServer
     ? ` \'\'`
-    : `(${RuntimeGlobals.publicPath} && ${RuntimeGlobals.publicPath}.indexOf('://') > 0 ? new URL(${RuntimeGlobals.publicPath}).origin : \'\')`;
+    : `(${publicPath} && ${publicPath}.indexOf('://') > 0 ? new URL(${publicPath}).origin : \'\')`;
 
   const constructedObject = Object.entries(content).reduce(
     (acc, [key, value]) => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,4 @@
-import { extractUrlAndGlobal } from './internal';
+import { extractUrlAndGlobal, customPromise as customPromiseTemplate } from './internal';
 
 const remoteVars = process.env.REMOTES || {};
 
@@ -108,3 +108,5 @@ export const injectScript = (keyOrRuntimeRemoteItem) => {
       return container;
     });
 };
+
+export const customPromise = customPromiseTemplate

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,11 @@
-import { extractUrlAndGlobal, customPromise as customPromiseTemplate } from './internal';
+// split the @ syntax into url and global
+export const extractUrlAndGlobal = (urlAndGlobal) => {
+  const index = urlAndGlobal.indexOf('@');
+  if (index <= 0 || index === urlAndGlobal.length - 1) {
+    throw new Error(`Invalid request "${urlAndGlobal}"`);
+  }
+  return [urlAndGlobal.substring(index + 1), urlAndGlobal.substring(0, index)];
+};
 
 const remoteVars = process.env.REMOTES || {};
 
@@ -108,5 +115,3 @@ export const injectScript = (keyOrRuntimeRemoteItem) => {
       return container;
     });
 };
-
-export const customPromise = customPromiseTemplate

--- a/src/utils.js
+++ b/src/utils.js
@@ -9,6 +9,8 @@ export const extractUrlAndGlobal = (urlAndGlobal) => {
 
 const remoteVars = process.env.REMOTES || {};
 
+console.log(remoteVars);
+
 const runtimeRemotes = Object.entries(remoteVars).reduce(function (acc, item) {
   const [key, value] = item;
   if (typeof value === 'object' && typeof value.then === 'function') {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3539,7 +3539,7 @@ watchpack@^2.3.0:
     glob-to-regexp "^0.4.1"
     graceful-fs "^4.1.2"
 
-webpack-sources@^3.2.2:
+webpack-sources@^3.2.2, webpack-sources@^3.2.3:
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-3.2.3.tgz#2d4daab8451fd4b240cc27055ff6a0c2ccea0cde"
   integrity sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==

--- a/yarn.lock
+++ b/yarn.lock
@@ -205,12 +205,118 @@
     estree-walker "^2.0.1"
     picomatch "^2.2.2"
 
+"@swc/core-android-arm-eabi@1.3.2":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@swc/core-android-arm-eabi/-/core-android-arm-eabi-1.3.2.tgz#55f11e0f01d568b832a59d0ff6156c14d5458c7a"
+  integrity sha512-jCqckwATVC4HbNjjrJii6xZzFKl7ecxVtY94odGD15+7qu5VCMuLD+Pj3bYxIQxQyzvi1z8S/187uUrAKMC2/w==
+  dependencies:
+    "@swc/wasm" "1.2.122"
+
+"@swc/core-android-arm64@1.3.2":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@swc/core-android-arm64/-/core-android-arm64-1.3.2.tgz#f3165028ec35d73103e1f5a928847356517199ce"
+  integrity sha512-zZ3EX5jmY6kTBlnAqLmIhDFGlsAB3Tiwk/sqoMLruZT1RsueDToQAXtjT5TWSlPh/GXAZyJQwqar2xIdi5pPAA==
+  dependencies:
+    "@swc/wasm" "1.2.130"
+
+"@swc/core-darwin-arm64@1.3.2":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@swc/core-darwin-arm64/-/core-darwin-arm64-1.3.2.tgz#ddd4e6daa505d08e6177f111be6a2caa31211d8b"
+  integrity sha512-YQpbRkd5zhycr+Nl1mm1p7koFqr8hsY8Z7XzNjfNIaJeFsXg9wjjH7yVmedQl+If+ibaPWpS3gMWfcIoUhdvGg==
+
+"@swc/core-darwin-x64@1.3.2":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@swc/core-darwin-x64/-/core-darwin-x64-1.3.2.tgz#057515579ccc52717a1c3938dffd0ac6e1ed2caa"
+  integrity sha512-DMvvdWgi/2dHtSGk4m6OcmlW8AAEUUl7Zys+Sxp+AtyIlQvn0Lbw9HCMPG6pqC0SHEO1kcNj6f6ARt3lL25jSA==
+
+"@swc/core-freebsd-x64@1.3.2":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@swc/core-freebsd-x64/-/core-freebsd-x64-1.3.2.tgz#1b80c6adc20a4bebe2a2dfc86acd47647d37dd75"
+  integrity sha512-GUXqDnmJTWZBoTbOMOKG+mw/jJ7dAOOKuUKwnQvyzconLkqHZZfJTimDsc1KWpikf9IPdQNY0+0/NqAVPGA0Dg==
+  dependencies:
+    "@swc/wasm" "1.2.130"
+
+"@swc/core-linux-arm-gnueabihf@1.3.2":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.3.2.tgz#7aa675f9daaa35319e95f22bf0d0e145340a338a"
+  integrity sha512-Df3ln4IhiFxOYBNr/x192tXhRBTVEhJPMLRDl9Q0WY/lvPp/n5Ee0VgKR1CaQ16bg3/z3lZjXrZRBw01kENEew==
+  dependencies:
+    "@swc/wasm" "1.2.130"
+
+"@swc/core-linux-arm64-gnu@1.3.2":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.3.2.tgz#a071167f4268a479c4e75e7a4b50f8dbf7aeaaa8"
+  integrity sha512-jPtcA61HqWFxlIr5OCToa97kqTS6u4I2GJR5whc8u2rSzn2N+M5CfqskOGHBETcEhUWfFa0hJq3+i6w9lqKV+w==
+
+"@swc/core-linux-arm64-musl@1.3.2":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.3.2.tgz#3b93f6ada83e09aaec3ca49fa08e13cabbc4a0a8"
+  integrity sha512-GhGM49GTzpjxKrzi8IpyHNlrJkOwiS6Pk4xhy3D7nrbB5KppU8O+lppkiRjiF9awD+mIzFq27TdokbmEoQcXaQ==
+
+"@swc/core-linux-x64-gnu@1.3.2":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.3.2.tgz#704f2e8a15f571dbe765269d7ffb656612eca1b2"
+  integrity sha512-JgN5rGHAKe2hvtU1H1V9toxSDWKEAWbrrb+/Wp/6CrxBxNgexmgXuDGt0VP21jbRA2qTRNEhx9zzuzZK9ggNTQ==
+
+"@swc/core-linux-x64-musl@1.3.2":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.3.2.tgz#e24868f942fae2931cf1e619e2bfa17194972408"
+  integrity sha512-VpT6jgU7qqNjQmKt5RaOpkocv9MI5FTxWon4OQvTc+kHCoTAmXIndaW6aA+j4VEDSTJ/7DQAFWSXpSCffoQMsA==
+
+"@swc/core-win32-arm64-msvc@1.3.2":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.3.2.tgz#c7ebc460e900f8934f7ae10ec6c9364b0953bba3"
+  integrity sha512-bilVzxfq5upHsil1WwPSoArZLkhPJyqJJ+5EzbiDS3Y38BPkPYZuN0h6sKuEiXLMHGODXtzuAkSgQyy0VVQKIA==
+  dependencies:
+    "@swc/wasm" "1.2.130"
+
+"@swc/core-win32-ia32-msvc@1.3.2":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.3.2.tgz#b9e802cec1db078cacae1a913492e8fb61b684f4"
+  integrity sha512-UzHbZvJnfGZKvoEPiHoKtKehtuiDuNP/mKKBAaG5Cnu8m47z/cE5Mi0onR2iJi1p64GX0RhRIBcGa8x9PVHGjA==
+  dependencies:
+    "@swc/wasm" "1.2.130"
+
+"@swc/core-win32-x64-msvc@1.3.2":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.3.2.tgz#a6c061a98bf6c70c42ac1fdf27674b085b768285"
+  integrity sha512-RSFgS2imGONhdN8anvDI+8wL+sinmeKUy2SmSiy8hSmqke1bCslirULCckyGzQAIMf3qCjuaTXxOFiQrsoSoIA==
+
+"@swc/core@^1.3.2":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@swc/core/-/core-1.3.2.tgz#86b1138f9b51e8476f39e2894944fc45585971fc"
+  integrity sha512-p2nLRVgtaz/v5UkNW9Ur5WrQUKB5YH1X7mE15UD2kihiAMc/04wvo0SNLW0BIeGSqeFdoZQ45TX5uOIxhAvRSg==
+  optionalDependencies:
+    "@swc/core-android-arm-eabi" "1.3.2"
+    "@swc/core-android-arm64" "1.3.2"
+    "@swc/core-darwin-arm64" "1.3.2"
+    "@swc/core-darwin-x64" "1.3.2"
+    "@swc/core-freebsd-x64" "1.3.2"
+    "@swc/core-linux-arm-gnueabihf" "1.3.2"
+    "@swc/core-linux-arm64-gnu" "1.3.2"
+    "@swc/core-linux-arm64-musl" "1.3.2"
+    "@swc/core-linux-x64-gnu" "1.3.2"
+    "@swc/core-linux-x64-musl" "1.3.2"
+    "@swc/core-win32-arm64-msvc" "1.3.2"
+    "@swc/core-win32-ia32-msvc" "1.3.2"
+    "@swc/core-win32-x64-msvc" "1.3.2"
+
 "@swc/helpers@0.4.11":
   version "0.4.11"
   resolved "https://registry.yarnpkg.com/@swc/helpers/-/helpers-0.4.11.tgz#db23a376761b3d31c26502122f349a21b592c8de"
   integrity sha512-rEUrBSGIoSFuYxwBYtlUFMlE2CwGhmW+w9355/5oduSw8e5h2+Tj4UrAGNNgP9915++wj5vkQo0UuOBqOAq4nw==
   dependencies:
     tslib "^2.4.0"
+
+"@swc/wasm@1.2.122":
+  version "1.2.122"
+  resolved "https://registry.yarnpkg.com/@swc/wasm/-/wasm-1.2.122.tgz#87a5e654b26a71b2e84b801f41e45f823b856639"
+  integrity sha512-sM1VCWQxmNhFtdxME+8UXNyPNhxNu7zdb6ikWpz0YKAQQFRGT5ThZgJrubEpah335SUToNg8pkdDF7ibVCjxbQ==
+
+"@swc/wasm@1.2.130":
+  version "1.2.130"
+  resolved "https://registry.yarnpkg.com/@swc/wasm/-/wasm-1.2.130.tgz#88ac26433335d1f957162a9a92f1450b73c176a0"
+  integrity sha512-rNcJsBxS70+pv8YUWwf5fRlWX6JoY/HJc25HD/F8m6Kv7XhJdqPPMhyX6TKkUBPAG7TWlZYoxa+rHAjPy4Cj3Q==
 
 "@types/eslint-scope@^3.7.0":
   version "3.7.3"


### PR DESCRIPTION
Adds support for complex promise factories in userland. 

```js
      remotes: {
            shop: promiseTemplate(
// remote entry must always be the first promise
              (resolve, reject) => {
                resolve('shop@http://localhost:3001/_next/static/chunks/remoteEntry.js');
              },
              (resolve,reject)=>{
              console.log('runing other promise');
              setTimeout(() => {
                console.log('resolving promise');
                resolve();
              } , 1000);
            }),
            checkout: "checkout@http",
             shop: promiseTemplate(
              // can also be a string if it needs to be computed in scope
              `(resolve, reject) => {
                resolve("${remotes.shop}");
              }`,
              (resolve,reject)=>{
              console.log('runing other promise');
              setTimeout(() => {
                console.log('resolving promise');
                resolve();
              } , 1000);
            }),
            another: promiseTemplate(
              'another@http://localhost:3001/_next/static/chunks/remoteEntry.js',
              (resolve,reject)=>{
              console.log('runing other promise');
              setTimeout(() => {
                console.log('resolving promise');
                resolve();
              } , 1000);
            }),
          },
```