### PR TITLE
feat: update the `next` peer dep in nextjs-mf

### DIFF
--- a/packages/nextjs-mf/package.json
+++ b/packages/nextjs-mf/package.json
@@ -19,6 +19,6 @@
   },
   "peerDependencies": {
     "webpack": "5.45.1",
-    "next": "11.0.1"
+    "next": "12.3.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1476,11 +1476,15 @@
   version "0.0.0"
   uid ""
 
-"@module-federation/node@0.0.1":
+"@module-federation/node@0.0.3":
   version "0.0.0"
   uid ""
 
 "@module-federation/node@link:./dist/packages/node":
+  version "0.0.0"
+  uid ""
+
+"@module-federation/utilities@0.0.2":
   version "0.0.0"
   uid ""
 


### PR DESCRIPTION
`nextjs-mf` package currently includes `next@11.0.1` as a **peer dependency** which is not the latest version.