### PR TITLE
Fix webpack validation error with UniversalFederationPlugin

### DIFF
--- a/packages/node/src/plugins/UniversalFederationPlugin.ts
+++ b/packages/node/src/plugins/UniversalFederationPlugin.ts
@@ -22,19 +22,18 @@ class UniversalFederationPlugin {
   }
 
   apply(compiler: Compiler) {
-    const isServer =
-      this.options.isServer || compiler.options.name === 'server';
+    const { isServer, ...options } = this.options;
     const { webpack } = compiler;
 
-    if (isServer) {
-      new NodeFederationPlugin(this.options, this.context).apply(compiler);
-      new StreamingTargetPlugin(this.options).apply(compiler);
+    if (isServer || compiler.options.name === 'server') {
+      new NodeFederationPlugin(options, this.context).apply(compiler);
+      new StreamingTargetPlugin(options).apply(compiler);
     } else {
       new (this.context.ModuleFederationPlugin ||
         (webpack && webpack.container.ModuleFederationPlugin) ||
-        require('webpack/lib/container/ModuleFederationPlugin'))(
-        this.options
-      ).apply(compiler);
+        require('webpack/lib/container/ModuleFederationPlugin'))(options).apply(
+        compiler
+      );
     }
   }
 }


### PR DESCRIPTION
```
ValidationError: Invalid options object. Module Federation Plugin has been initialized using an options object that does not match the API schema.
 - options has an unknown property 'isServer'.
```

Above error was thrown when passing isServer to the plugin due to the whole options object got passed further to ModuleFederationPlugin & isServer was not a valid option. Just need to extract it out & pass through the rest.

https://github.com/module-federation/node/pull/17