### PR TITLE
fix(node): fix path to webpack hmr runtime

### DIFF
--- a/packages/node/src/plugins/LoadFileChunkLoadingRuntimeModule.ts
+++ b/packages/node/src/plugins/LoadFileChunkLoadingRuntimeModule.ts
@@ -378,7 +378,7 @@ class ReadFileChunkLoadingRuntimeModule extends RuntimeModule {
             '}',
             '',
             Template.getFunctionContent(
-              require('../hmr/JavascriptHotModuleReplacement.runtime.js')
+              require('webpack/lib/hmr/JavascriptHotModuleReplacement.runtime.js')
             )
               .replace(/\$key\$/g, 'readFileVm')
               .replace(/\$installedChunks\$/g, 'installedChunks')


### PR DESCRIPTION
Update path to Webpack's HMR runtime to not depend on relative paths.

This is the same change made in the [module-federation/node](https://github.com/module-federation/node) repo.
Apparently, the change was lost during the relocation.

See related issue and PR:
- https://github.com/module-federation/node/issues/7
- https://github.com/module-federation/node/pull/8
