### PR TITLE
Adds unique key override to injectScript

### DIFF
--- a/packages/utilities/src/types/index.ts
+++ b/packages/utilities/src/types/index.ts
@@ -12,8 +12,8 @@ declare const __webpack_share_scopes__: Record<
   Record<
     string,
     { loaded?: 1; get: () => Promise<unknown>; from: string; eager: boolean }
-    >
-  >;
+  >
+>;
 
 export interface NextFederationPluginExtraOptions {
   enableImageLoaderFix?: boolean;
@@ -51,6 +51,7 @@ export type AsyncContainer = Promise<WebpackRemoteContainer>;
 export type RemoteData = {
   global: string;
   url: string;
+  uniqueKey?: string;
 };
 
 export type RuntimeRemote = Partial<RemoteData> & {

--- a/packages/utilities/src/utils/common.ts
+++ b/packages/utilities/src/utils/common.ts
@@ -115,7 +115,7 @@ export const injectScript = (
             ': ' +
             realSrc +
             ' or global var ' +
-            containerKey +
+            remoteGlobal +
             ')';
 
           __webpack_error__.name = 'ScriptExternalLoadError';

--- a/packages/utilities/src/utils/common.ts
+++ b/packages/utilities/src/utils/common.ts
@@ -88,19 +88,19 @@ export const injectScript = (
     asyncContainer = new Promise(function (resolve, reject) {
       function resolveRemoteGlobal() {
         const asyncContainer = window[
-          containerKey
+          remoteGlobal
         ] as unknown as AsyncContainer;
         return resolve(asyncContainer);
       }
 
-      if (typeof window[containerKey] !== 'undefined') {
+      if (typeof window[remoteGlobal] !== 'undefined') {
         return resolveRemoteGlobal();
       }
 
       (__webpack_require__ as any).l(
         reference.url,
         function (event: Event) {
-          if (typeof window[containerKey] !== 'undefined') {
+          if (typeof window[remoteGlobal] !== 'undefined') {
             return resolveRemoteGlobal();
           }
 

--- a/packages/utilities/src/utils/common.ts
+++ b/packages/utilities/src/utils/common.ts
@@ -2,7 +2,7 @@ import type {
   AsyncContainer,
   Remotes,
   RuntimeRemotesMap,
-  RuntimeRemote
+  RuntimeRemote,
 } from '../types';
 
 // @ts-ignore
@@ -74,6 +74,12 @@ export const injectScript = (
     // This casting is just to satisfy typescript,
     // In reality remoteGlobal will always be a string;
     const remoteGlobal = reference.global as unknown as number;
+
+    // Check if theres an ovveride for container key if not use remote global
+    const containerKey = reference.uniqueKey
+      ? (reference.uniqueKey as unknown as number)
+      : remoteGlobal;
+
     const __webpack_error__ = new Error() as Error & {
       type: string;
       request: string | null;
@@ -82,19 +88,19 @@ export const injectScript = (
     asyncContainer = new Promise(function (resolve, reject) {
       function resolveRemoteGlobal() {
         const asyncContainer = window[
-          remoteGlobal
+          containerKey
         ] as unknown as AsyncContainer;
         return resolve(asyncContainer);
       }
 
-      if (typeof window[remoteGlobal] !== 'undefined') {
+      if (typeof window[containerKey] !== 'undefined') {
         return resolveRemoteGlobal();
       }
 
       (__webpack_require__ as any).l(
         reference.url,
         function (event: Event) {
-          if (typeof window[remoteGlobal] !== 'undefined') {
+          if (typeof window[containerKey] !== 'undefined') {
             return resolveRemoteGlobal();
           }
 
@@ -109,7 +115,7 @@ export const injectScript = (
             ': ' +
             realSrc +
             ' or global var ' +
-            remoteGlobal +
+            containerKey +
             ')';
 
           __webpack_error__.name = 'ScriptExternalLoadError';
@@ -118,7 +124,7 @@ export const injectScript = (
 
           reject(__webpack_error__);
         },
-        remoteGlobal
+        containerKey
       );
     });
   }


### PR DESCRIPTION
My application needs to swap out the same global with different remotes. Adding a unique key to optionally override the default container key allows us to load in the new remote when necessary.