### PR TITLE
(typescript) Use expose public path as basis for @mf-typescript output structure

### DIFF
--- a/packages/typescript/README.md
+++ b/packages/typescript/README.md
@@ -34,13 +34,16 @@ plugins: [
 
 You need to register this plugin in both remote and host apps. The plugin will automatically create a directory named `@mf-typescript` in the host app - that contains all the types exported by the remote apps.
 
-In your file:
-```typescript
-import RemoteButtonType from "../@mf-typescript/Button";
+To have the type definitions automatically found for imports, add `paths` in `tsconfig.json`:
 
-const RemoteButton = React.lazy(
-  () => import("app2/Button")
-) as unknown as typeof RemoteButtonType;
+```json
+{
+  "compilerOptions": {
+    "paths": {
+      "*": ["./@mf-typescript/*"]
+    }
+  },
+}
 ```
 
 ### Usage in Next.js


### PR DESCRIPTION
I thought it would make sense to have the output mirror the `exposes` keys (public path) as opposed to the original source path. e.g.

```js
// "expose/public/path": "source/path",
"./atoms/Counter": "lib/Counter",
"./molecules/Header": "lib/Header",
```
now gives

```
@mf-typescript/
├─ atoms/
│  ├─ Counter.d.ts
├─ molecules/
│  ├─ Header.d.ts
```

With this change, the federated module imports now match the type definition folder structure
```js
import Header from '[remote]/molecules/Header';
// types can be found in `@mf-typescript/[remote]/molecules/Header.d.ts`
```
so instead of manually importing the types and casting with `as unknown as typeof CounterType`, we can add `@mf-typescript` to the `paths` array in `tsconfig.json` and all the types will picked up by the compiler

```json
{
  "compilerOptions": {
    "paths": {
      "*": ["./@mf-typescript/*"]
      }
  }
}
```