### PR TITLE
fix(node): add node-fetch fallback in node hot-reload util

### DIFF
--- a/packages/node/src/utils/hot-reload.js
+++ b/packages/node/src/utils/hot-reload.js
@@ -13,7 +13,7 @@ export const revalidate = (options) => {
         }
         const name = property;
         const url = remote;
-        (global.webpackChunkLoad || fetch)(url)
+        (global.webpackChunkLoad || global.fetch || require('node-fetch'))(url)
           .then((re) => {
             if(!re.ok) {
               throw new Error(`Error loading remote: status: ${re.status}, content-type: ${re.headers.get("content-type")}`);


### PR DESCRIPTION
Add node-fetch fallback in node hot-reload util.

As global fetch is available in Node.js v18+, this code throws an error in previous Node.js versions as `fetch` is `undefined`.
Uses the same approach as NodeFederationPlugin [here](https://github.com/apehead/nextjs-mf/blob/4a5e2824400cc843fa0c0504936a68c6c9f33946/packages/node/src/plugins/NodeFederationPlugin.ts#L56).


