### PR TITLE
fix: preserve path of exposed `.d.ts` files

### DIFF
--- a/packages/typescript/src/lib/Typescript.ts
+++ b/packages/typescript/src/lib/Typescript.ts
@@ -110,7 +110,9 @@ export class FederatedTypesPlugin {
             indexFileResp.data?.forEach((file) =>
               download(
                 `${origin}/${this.typescriptFolderName}/${file}`,
-                `${this.typescriptFolderName}/${remote}`
+                `${this.typescriptFolderName}/${remote}`, {
+                  filename: file
+                }
               )
             );
           })


### PR DESCRIPTION
When downloading the types from a remote, we need to preserve the folder structure of those components to avoid name collisions. 

Take this for example, remote-1 exposes the following: 

```
| - Accordion
|   | - Item.d.ts
|   | - Header.d.ts
|   | - index.d.ts
| - Markdown
|   | - Primitive.d.ts
| - Spinner
|   | - index.d.ts
| - Combobox
|   | - index.d.ts
| - Dialog
|   | - index.d.ts
| - Icon
|   | - index.d.ts
| - __types_index.json
```

Many of these files have `index.d.ts`. You'll notice that the result of downloading the types on the consumer  is incorrect due to the name collision:

```
| - remote-1
|   | - Item.d.ts
|   | - Header.d.ts
|   | - Primitive.d.ts
|   | - index.d.ts
```
Once my small fix is applied to preserve the folder structure, you'll end up with the following result on the consumer:

```
| - remote-1
|   | - Item.d.ts
|   | - Header.d.ts
|   | - Accordion
|   |    | - Item.d.ts
|   |    | - Header.d.ts
|   |    | - index.d.ts
|   | - Markdown
|   |    | - Primitive.d.ts
|   | - Primitive.d.ts
|   | - Spinner
|   |    | - index.d.ts
|   | - Combobox
|   |    | - index.d.ts
|   | - Dialog
|   |    | - index.d.ts
|   | - Icon
|   |    | - index.d.ts
|   | - index.d.ts
```
