### PR TITLE
fix: flush CSS chunks, cache bust remote entry on render

### DIFF
--- a/packages/nextjs-mf/utils/index.ts
+++ b/packages/nextjs-mf/utils/index.ts
@@ -17,11 +17,23 @@ export const revalidate = () => {
 //@ts-ignore
 export const FlushedChunks = ({ chunks })=>{
   //@ts-ignore
-  const scripts = chunks.filter((c)=>c.endsWith(".js")).map((chunk)=>/*#__PURE__*/ React.createElement("script", {
-    src: chunk,
-    async: true
-  }, null));
-  return scripts;
+  const scripts = chunks.filter((c)=>c.endsWith(".js")).map((chunk)=> {
+    if(!chunk.includes('?') && chunk.includes('remoteEntry')) {
+      chunk = chunk + '?t=' + Date.now();
+    }
+    return React.createElement("script", {
+      src: chunk,
+      async: true
+    }, null)
+  });
+  //@ts-ignore
+  const css = chunks.filter((c)=>c.endsWith(".css")).map((chunk)=> {
+    return React.createElement("link", {
+      href: chunk,
+      rel: "stylesheet"
+    }, null)
+  });
+  return [css,scripts];
 };
 FlushedChunks.defaultProps = {
   chunks: []

--- a/yarn.lock
+++ b/yarn.lock
@@ -1646,7 +1646,7 @@
   version "0.0.0"
   uid ""
 
-"@module-federation/node@0.3.0":
+"@module-federation/node@0.5.0":
   version "0.0.0"
   uid ""
 
@@ -1654,7 +1654,7 @@
   version "0.0.0"
   uid ""
 
-"@module-federation/utilities@0.0.2":
+"@module-federation/utilities@0.0.4":
   version "0.0.0"
   uid ""
 


### PR DESCRIPTION
Ensure css links are rendered into the head. Ensure that when remote entry js is server rendered is includes a datestamp to cache bust it