### PR TITLE
fix: fix node plugin fs augments when outside next child compiler

### DIFF
--- a/packages/node/src/plugins/NodeFederationPlugin.ts
+++ b/packages/node/src/plugins/NodeFederationPlugin.ts
@@ -81,6 +81,7 @@ const executeLoadTemplate = `
             return executeLoad(remoteUrl, true);
           }
           console.warn(moduleName,'is offline, returning fake remote')
+
           return {
             fake: true,
             get:(arg)=>{
@@ -127,7 +128,7 @@ function buildRemotes(
     ${executeLoadTemplate}
     resolve(executeLoad(${JSON.stringify(config)}))
     }).then(remote=>{
-      if(!global.usedChunks || remote.fake) {
+      if(remote.fake) {
         return remote;
       }
 
@@ -141,7 +142,7 @@ function buildRemotes(
           const m = f();
           return ()=>new Proxy(m, {
             get: (target, prop)=>{
-            global.usedChunks.add(${JSON.stringify(global)} + "->" + arg);
+            if(global.usedChunks) global.usedChunks.add(${JSON.stringify(global)} + "->" + arg);
               return target[prop];
             }
           })
@@ -151,7 +152,7 @@ function buildRemotes(
         global.__remote_scope__[${JSON.stringify(global)}].__initialized = true;
           return remote.init(new Proxy(args, {
             set: (target, prop, value)=>{
-              global.usedChunks.add(${JSON.stringify(global)} + "->" + prop);
+              if(global.usedChunks) global.usedChunks.add(${JSON.stringify(global)} + "->" + prop);
               target[prop] = value;
               return true;
             }

--- a/packages/node/src/plugins/StreamingTargetPlugin.ts
+++ b/packages/node/src/plugins/StreamingTargetPlugin.ts
@@ -37,8 +37,7 @@ class StreamingTargetPlugin {
     // Can't use the 'false' value as it isn't the right format,
     // Perhaps delete the option might solve our use case.
 
-    // compiler.options.output.enabledChunkLoadingTypes = false;
-    delete compiler.options.output.enabledChunkLoadingTypes;
+    compiler.options.output.enabledChunkLoadingTypes = [];
 
     new ((webpack && webpack.node && webpack.node.NodeEnvironmentPlugin) ||
       require('webpack/lib/node/NodeEnvironmentPlugin'))({

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -5,15 +5,10 @@
   "main": "src/index.js",
   "types": "src/index.d.ts",
   "exports": {
-    "/": {
-      "import": "./src/index.js",
-      "require": "./src/index.js"
-    },
-    "/package.json": "./package.json",
-    "/react": {
-      "import": "./src/utils/react.js",
-      "require": "./src/utils/react.js"
-    }
+    ".": "./src/index.js",
+    "./package.json": "./package.json",
+    "./react": "./src/utils/react.js",
+    "./*": "./src/"
   },
   "repository": "https://github.com/module-federation/nextjs-mf/tree/main/packages/utilities",
   "peerDependencies": {

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -5,12 +5,12 @@
   "main": "src/index.js",
   "types": "src/index.d.ts",
   "exports": {
-    ".": {
+    "/": {
       "import": "./src/index.js",
       "require": "./src/index.js"
     },
-    "./package.json": "./package.json",
-    "./react": {
+    "/package.json": "./package.json",
+    "/react": {
       "import": "./src/utils/react.js",
       "require": "./src/utils/react.js"
     }

--- a/packages/utilities/src/utils/common.ts
+++ b/packages/utilities/src/utils/common.ts
@@ -5,9 +5,15 @@ import type {
   RuntimeRemote,
 } from '../types';
 
-// @ts-ignore
-const remoteVars = (process.env.REMOTES || {}) as Record<string,
+let remoteVars = {} as Record<string,
   Promise<any> | string | (() => Promise<any>)>;
+try {
+  // @ts-ignore
+  remoteVars = (process.env.REMOTES || {}) as Record<string,
+    Promise<any> | string | (() => Promise<any>)>;
+} catch (e) {
+  console.error('Error parsing REMOTES environment variable', e);
+}
 
 // split the @ syntax into url and global
 export const extractUrlAndGlobal = (urlAndGlobal: string): [string, string] => {

--- a/packages/utilities/src/utils/react.tsx
+++ b/packages/utilities/src/utils/react.tsx
@@ -27,6 +27,7 @@ class ErrorBoundary extends React.Component<any, any> {
  * Wrapper around dynamic import.
  * Adds error boundaries and fallback options
  */
+
 export const FederationBoundary = ({
   dynamicImporter,
   fallback = () => null,


### PR DESCRIPTION
Node plugin adds additional copies of readFileVM when not in child compiler if enabledLibraryTypes is unset