### PR TITLE
repro: error when module is esm format

### DIFF
--- a/apps/3000-home/components/SharedNav.tsx
+++ b/apps/3000-home/components/SharedNav.tsx
@@ -4,6 +4,9 @@ import { useRouter } from 'next/router';
 // @ts-ignore
 import {tjhin} from './thing.module.css'
 import { useMFRemote } from '@module-federation/nextjs-mf/client';
+import cookie from 'js-cookie'
+
+console.log(cookie)
 
 const SharedNav = () => {
   const { asPath, push } = useRouter();

--- a/apps/3000-home/package.json
+++ b/apps/3000-home/package.json
@@ -7,7 +7,8 @@
     "lodash": "4.17.21",
     "next": "12.3.0",
     "react": "18.2.0",
-    "react-dom": "18.2.0"
+    "react-dom": "18.2.0",
+    "js-cookie": "^3.0.1"
   },
   "devDependencies": {
     "@module-federation/nextjs-mf": "link:../../dist/packages/nextjs-mf"


### PR DESCRIPTION
If importing `js-cookie` in exposed module (which is ESM) the compile fails:

repro steps. `yarn start` then try and visit localhost:3000

```bash
[3000-home      ] error - external "js-cookie"
[3000-home      ] The target environment doesn't support dynamic import() syntax so it's not possible to use external type 'module' within a script
```


If I set `compiler.options.externals = []` - the error goes away, but the parent compilation now bundles all node modules. 

It seems to be inheriting the parent compilation externals function instead of letting me override it

potential fix? https://github.com/module-federation/nextjs-mf/pull/296