### PR TITLE
Feat: Typescript -emit error handling, and options for the Typescript compiler

### DIFF
--- a/packages/typescript/src/lib/Typescript.ts
+++ b/packages/typescript/src/lib/Typescript.ts
@@ -8,15 +8,13 @@ import get from 'lodash.get';
 import axios from 'axios';
 import { Compilation, Compiler } from 'webpack';
 
-namespace FederatedTypesPlugin {
-  export interface FederatedTypesPluginOptions {
-    /**
-     * Any additional files to be included (besides `ModuleFederationPluginOptions.remotes`) in the emission of Typescript types.
-     * I.e. `"files"` in your tsconfig.json.
-     * This is useful for global .d.ts files not directly referenced.
-     */
-    typescriptFilesInclude?: string[];
-  }
+export interface FederatedTypesPluginOptions {
+  /**
+   * Any additional files to be included (besides `ModuleFederationPluginOptions.remotes`) in the emission of Typescript types.
+   * I.e. `"files"` in your tsconfig.json.
+   * This is useful for global .d.ts files not directly referenced.
+   */
+  typescriptFilesInclude?: string[];
 }
 
 export class FederatedTypesPlugin {
@@ -30,13 +28,13 @@ export class FederatedTypesPlugin {
   private webpackCompilerOptions!: Compiler['options'];
 
   private tsDefinitionFilesObj: Record<string, string> = {};
-  private federatedTypesPluginOptions?: FederatedTypesPlugin.FederatedTypesPluginOptions;
+  private federatedTypesPluginOptions?: FederatedTypesPluginOptions;
   private typescriptFolderName = '@mf-typescript';
   private typesIndexJsonFileName = '__types_index.json';
 
   constructor(
     options: ModuleFederationPluginOptions,
-    federatedTypesPluginOptions?: FederatedTypesPlugin.FederatedTypesPluginOptions
+    federatedTypesPluginOptions?: FederatedTypesPluginOptions
   ) {
     this.options = options;
     this.tsCompilerOptions = {

--- a/packages/typescript/src/lib/Typescript.ts
+++ b/packages/typescript/src/lib/Typescript.ts
@@ -213,15 +213,6 @@ export class FederatedTypesPlugin {
             }
           }
         );
-      } else {
-        const shortformErrors = emitResult.diagnostics.map((result) => ({
-          fileName: result.file?.fileName,
-          error: `TS${result.code}: ${result.messageText}`,
-        }));
-        console.error(
-          '[FederatedTypesPlugin]: Declaration emit failed. The following files are erroneous:\n',
-          shortformErrors
-        );
       }
     }
   }


### PR DESCRIPTION
Hello

~~This PR seeks to propagate errors when `ts.createProgram().emit()` fails. Essentially Typescript errors, that are not immediately obvious to the user as declaration emit is done with a separate set of rules from their local tsconfig.json ruleset. If this step currently fails further failures will continue in the plugin since `importRemoteTypes()` depends on this step being complete.~~

Moreover, I add the option of including additional files in this step, besides those referenced by `"ModuleFederationPluginOptions.remotes"`. This is particularly useful if the user has global declaration files (think `declaration.d.ts`, `dom.d.ts`, etc.), that are not imported or directly referenced in the code.