### PR TITLE
fix: hot-reload not working when node-fetch is imported from require()

### DIFF
--- a/packages/node/src/utils/hot-reload.ts
+++ b/packages/node/src/utils/hot-reload.ts
@@ -40,12 +40,9 @@ export const revalidate = () => {
 
         const name = property;
         const url = remote;
+        const fetchModule = getFetchModule()
 
-        const fetcher = (
-          global.webpackChunkLoad ||
-          global.fetch ||
-          require('node-fetch')
-        )(url)
+        const fetcher = fetchModule(url)
           .then((re: Response) => {
             if (!re.ok) {
               throw new Error(
@@ -118,3 +115,12 @@ export const revalidate = () => {
 
   return Promise.resolve(false);
 };
+
+function getFetchModule() {
+  const loadedModule = global.webpackChunkLoad || global.fetch
+  if (loadedModule) {
+    return loadedModule
+  }
+  const nodeFetch = require('node-fetch')
+  return nodeFetch.default || nodeFetch
+}


### PR DESCRIPTION
Fixes part of #351 