### PR TITLE
ci: publish individual packages manually

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -22,10 +22,6 @@ jobs:
           git config user.email "gituser@example.com"
       - run: git fetch --no-tags --prune --depth=5 origin main
         name: Fetch Main branch
-      # - uses: actions/setup-node@v3
-      #   with:
-      #     node-version: '14'
-      #     cache: 'yarn'
       - name: Install packages
         run: yarn install --frozen-lockfile
       - name: Lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
           if [[ "$PROJECTS" ]]; then
             yarn nx run-many --target=build --projects="$PROJECTS"
           else
-            echo "No changes, Skipping lint check."
+            echo "No changes, Skipping build check."
           fi
       - name: Version
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,18 @@
 name: Release
 
 on:
-  push:
-    branches:
-      - main
+  workflow_dispatch:
+    inputs:
+      package:
+        description: 'Packages to Publish'
+        required: true
+        type: choice
+        options:
+          - all
+          - nextjs-mf
+          - node
+          - typescript
+          - utils
 
 jobs:
   release:
@@ -16,23 +25,44 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: '16'
+          cache: 'yarn'
       - name: Setup Git
         run: |
           git config user.name "GitHub Bot"
           git config user.email "gituser@example.com"
-      - uses: actions/setup-node@v3
-        with:
-          node-version: '14'
-          cache: 'yarn'
       - name: Install packages
         run: yarn install --frozen-lockfile
+      - name: Lint
+        shell: bash
+        run: |
+          PROJECTS=$($(yarn bin)/nx print-affected --type=lib --select=projects --base=origin/main)
+          if [[ "$PROJECTS" ]]; then
+            yarn nx run-many --target=lint --projects="$PROJECTS"
+          else
+            echo "No changes, Skipping lint check."
+          fi
+      - name: Build
+        shell: bash
+        run: |
+          PROJECTS=$($(yarn bin)/nx print-affected --type=lib --select=projects --base=origin/main)
+          if [[ "$PROJECTS" ]]; then
+            yarn nx run-many --target=build --projects="$PROJECTS"
+          else
+            echo "No changes, Skipping lint check."
+          fi
       - name: Version
         shell: bash
         run: |
           npm config set '//registry.npmjs.org/:_authToken' "${NPM_TOKEN}"
-          PROJECTS=$($(yarn bin)/nx print-affected --type=lib --select=projects --base=last-release)
+
+          PROJECTS=${{ inputs.projects }}
+
+          if [[ $PROJECTS == "all" ]]; then
+            PROJECTS=$($(yarn bin)/nx print-affected --type=lib --select=projects --base=last-release)
+          fi;
+
           echo $PROJECTS
-          yarn nx run-many --target=build --projects="$PROJECTS" --parallel=1
+
           yarn nx run-many --target=version --projects="$PROJECTS" --parallel=1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Currently, all packages within the repository gets published to NPM whenever a  PR gets merged into the `main` branch.

Although this workflow achieves `Continuous Deployment`, it also poses an issue where one/more of the other packages might not be ready to be published especially in scenarios for **`BREAKING CHANGES`** as described in #299.

This PR addresses the issue by manually releasing package(s) by choosing which package to be released at release time.

For more information on how the workflow will work can be found in the [GitHub Actions Documentation](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch)  

fixes #299