### PR TITLE
feat(utils): configurable logger using webpack infrastructure logger

### DIFF
--- a/packages/utilities/src/Logger.ts
+++ b/packages/utilities/src/Logger.ts
@@ -1,0 +1,16 @@
+import { Compilation } from 'webpack';
+
+export type LoggerInstance = Compilation['logger'] | Console;
+
+export class Logger {
+  private static loggerInstance: LoggerInstance = console;
+
+  static getLogger(): LoggerInstance {
+    return this.loggerInstance;
+  }
+
+  static setLogger(logger: Compilation['logger']): LoggerInstance {
+    this.loggerInstance = logger || console;
+    return logger;
+  }
+}

--- a/packages/utilities/src/index.ts
+++ b/packages/utilities/src/index.ts
@@ -1,2 +1,3 @@
 export * from './types';
 export * from './utils/common';
+export * from './Logger';


### PR DESCRIPTION
Usage:

In the `webpack plugin#apply` method, extract `infrastructure logger` and set it to the logger constructor

```typescript
import type { Compiler } from 'webpack';
import { Logger } from '@module-federation/utilities';

class SomePlugin {
  apply(compiler: Compiler) {
    this.logger = Logger.setLogger(
      compiler.getInfrastructureLogger(PLUGIN_NAME)
    );

    // somewhere else in the plugin
    this.logger.log("do the log here");
  }
}
```

closes #243