### PR TITLE
feat(node): add flag to control logging

### DIFF
--- a/packages/node/src/plugins/CommonJsChunkLoadingPlugin.ts
+++ b/packages/node/src/plugins/CommonJsChunkLoadingPlugin.ts
@@ -20,7 +20,8 @@ class CommonJsChunkLoadingPlugin {
   private _asyncChunkLoading: boolean;
 
   constructor(options: CommonJsChunkLoadingOptions) {
-    this.options = {...(options || ({} as CommonJsChunkLoadingOptions)), verbose: options?.verbose ?? false};
+    options.verbose ??= false;
+    this.options = options || ({} as CommonJsChunkLoadingOptions);
     this._asyncChunkLoading = this.options.asyncChunkLoading;
   }
 

--- a/packages/node/src/plugins/CommonJsChunkLoadingPlugin.ts
+++ b/packages/node/src/plugins/CommonJsChunkLoadingPlugin.ts
@@ -12,6 +12,7 @@ interface CommonJsChunkLoadingOptions extends ModuleFederationPluginOptions {
   remotes: Record<string, string>;
   name?: string;
   asyncChunkLoading: boolean;
+  verbose?: boolean;
 }
 
 class CommonJsChunkLoadingPlugin {
@@ -19,7 +20,7 @@ class CommonJsChunkLoadingPlugin {
   private _asyncChunkLoading: boolean;
 
   constructor(options: CommonJsChunkLoadingOptions) {
-    this.options = options || ({} as CommonJsChunkLoadingOptions);
+    this.options = {...(options || ({} as CommonJsChunkLoadingOptions)), verbose: options?.verbose ?? false};
     this._asyncChunkLoading = this.options.asyncChunkLoading;
   }
 

--- a/packages/node/src/plugins/LoadFileChunkLoadingRuntimeModule.ts
+++ b/packages/node/src/plugins/LoadFileChunkLoadingRuntimeModule.ts
@@ -40,7 +40,9 @@ class ReadFileChunkLoadingRuntimeModule extends RuntimeModule {
   ) {
     super('readFile chunk loading', RuntimeModule.STAGE_ATTACH);
     this.runtimeRequirements = runtimeRequirements;
-    this.options = {...options, verbose: options.verbose ?? false};
+
+    options.verbose ??= false;
+    this.options = options;
     this.chunkLoadingContext = chunkLoadingContext;
   }
 

--- a/packages/node/src/plugins/StreamingTargetPlugin.ts
+++ b/packages/node/src/plugins/StreamingTargetPlugin.ts
@@ -15,7 +15,8 @@ class StreamingTargetPlugin {
   private options: StreamingTargetOptions;
 
   constructor(options: StreamingTargetOptions) {
-    this.options = {...(options || {}), verbose: options?.verbose ?? false};
+    options.verbose ??= false;
+    this.options = options || {};
   }
 
   apply(compiler: Compiler) {

--- a/packages/node/src/plugins/StreamingTargetPlugin.ts
+++ b/packages/node/src/plugins/StreamingTargetPlugin.ts
@@ -5,6 +5,7 @@ import CommonJsChunkLoadingPlugin from './CommonJsChunkLoadingPlugin';
 
 interface StreamingTargetOptions extends ModuleFederationPluginOptions {
   promiseBaseURI?: string;
+  verbose?: boolean;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
@@ -14,7 +15,7 @@ class StreamingTargetPlugin {
   private options: StreamingTargetOptions;
 
   constructor(options: StreamingTargetOptions) {
-    this.options = options || {};
+    this.options = {...(options || {}), verbose: options?.verbose ?? false};
   }
 
   apply(compiler: Compiler) {
@@ -56,6 +57,7 @@ class StreamingTargetPlugin {
       remotes: this.options.remotes as Record<string, string>,
       baseURI: compiler.options.output.publicPath,
       promiseBaseURI: this.options.promiseBaseURI,
+      verbose: this.options.verbose
     }).apply(compiler);
   }
 }

--- a/packages/node/src/plugins/UniversalFederationPlugin.ts
+++ b/packages/node/src/plugins/UniversalFederationPlugin.ts
@@ -18,7 +18,8 @@ class UniversalFederationPlugin {
   private context: NodeFederationContext;
 
   constructor(options: NodeFederationOptions, context: NodeFederationContext) {
-    this.options = {...(options || {} as NodeFederationOptions), verbose: options?.verbose ?? false};
+    options.verbose ??= false;
+    this.options = options || {} as NodeFederationOptions;
     this.context = context || {} as NodeFederationContext;
   }
 

--- a/packages/node/src/plugins/UniversalFederationPlugin.ts
+++ b/packages/node/src/plugins/UniversalFederationPlugin.ts
@@ -6,6 +6,7 @@ import type { Compiler, container } from 'webpack';
 interface NodeFederationOptions extends ModuleFederationPluginOptions {
   isServer: boolean;
   promiseBaseURI?: string;
+  verbose?: boolean;
 }
 
 interface NodeFederationContext {
@@ -17,17 +18,17 @@ class UniversalFederationPlugin {
   private context: NodeFederationContext;
 
   constructor(options: NodeFederationOptions, context: NodeFederationContext) {
-    this.options = options || {} as NodeFederationOptions;
+    this.options = {...(options || {} as NodeFederationOptions), verbose: options?.verbose ?? false};
     this.context = context || {} as NodeFederationContext;
   }
 
   apply(compiler: Compiler) {
-    const { isServer, ...options } = this.options;
+    const { isServer, verbose, ...options } = this.options;
     const { webpack } = compiler;
 
     if (isServer || compiler.options.name === 'server') {
       new NodeFederationPlugin(options, this.context).apply(compiler);
-      new StreamingTargetPlugin(options).apply(compiler);
+      new StreamingTargetPlugin({...options, verbose}).apply(compiler);
     } else {
       new (this.context.ModuleFederationPlugin ||
         (webpack && webpack.container.ModuleFederationPlugin) ||

--- a/yarn.lock
+++ b/yarn.lock
@@ -1645,9 +1645,11 @@
 
 "@module-federation/nextjs-mf@link:./dist/packages/nextjs-mf":
   version "0.0.0"
+  uid ""
 
 "@module-federation/nextjs-mf@link:dist/packages/nextjs-mf":
   version "0.0.0"
+  uid ""
 
 "@module-federation/node@link:./dist/packages/node":
   version "0.0.0"
@@ -1657,12 +1659,9 @@
   version "0.0.0"
   uid ""
 
-"@module-federation/utilities@0.3.0":
-  version "0.0.0"
-  uid ""
-
 "@module-federation/utilities@link:./dist/packages/utilities":
   version "0.0.0"
+  uid ""
 
 "@next/env@13.0.0":
   version "13.0.0"


### PR DESCRIPTION
Currently, a high level of logging is produced when using the `module-federation/node` package.

This creates an unnecessary amount of noise, especially for production environments.

The logging is still useful for debug purposes however, so it should not be completely removed. 

This PR introduces a `verbose` flag that defaults to `false` to allow building production builds. If debugging is still required, you can set `verbose` to true in the options for the plugins.