### PR TITLE
fix: support images for storages and local debug

### DIFF
--- a/packages/nextjs-mf/src/loaders/fixImageLoader.ts
+++ b/packages/nextjs-mf/src/loaders/fixImageLoader.ts
@@ -31,8 +31,6 @@ export async function fixImageLoader(
 
   const content = (result.default || result) as Record<string, string>;
 
-  // `function getSSRImagePath(){const remoteEntry = global.__remote_scope__._config[global.remoteEntryName];return remoteEntry.split('/').slice(0, remoteEntry.split('/').length - 4).join('/');}()`
-
   const computedAssetPrefix = isServer
     ? `${Template.asString([
         'function getSSRImagePath(){',


### PR DESCRIPTION
this pr will calculate the ssr images relative to the remote entry package instead of getting the origin,
so as long as the file system will be exactly as next dist directory, it will work

#392 