### PR TITLE
fix(node): verbose false should not log

### DIFF
--- a/packages/node/src/plugins/LoadFileChunkLoadingRuntimeModule.ts
+++ b/packages/node/src/plugins/LoadFileChunkLoadingRuntimeModule.ts
@@ -69,7 +69,7 @@ class ReadFileChunkLoadingRuntimeModule extends RuntimeModule {
    * @param {unknown[]} items item to log
    */
   _getLogger(...items: unknown[]) {
-    if (this.options.verbose) {
+    if (!this.options.verbose) {
       return "";
     }
 


### PR DESCRIPTION
A mistake was made in the _getLogger function which led to inverted expectations from the verbose flag