### PR TITLE
fix: throw correct error object instead of an empty error in FederatedTypesPlugin

### DIFF
--- a/packages/typescript/src/plugins/FederatedTypesPlugin.ts
+++ b/packages/typescript/src/plugins/FederatedTypesPlugin.ts
@@ -126,7 +126,7 @@ export class FederatedTypesPlugin {
       return filesMap;
     } catch (error) {
       this.logger.error(error);
-      throw new Error();
+      throw error;
     }
   }
 


### PR DESCRIPTION
FederatedTypesPlugin was throwing an empty error when encountered an error, It wassn't possible to see the error unless we dig into the node_modules folder and throw the correct error.