### PR TITLE
docs(nextjs-mf): fix path to include-defaults

### DIFF
--- a/packages/nextjs-mf/README.md
+++ b/packages/nextjs-mf/README.md
@@ -165,7 +165,7 @@ module.exports = {
 
 // _app.js or some other file in as high up in the app (like next's new layouts)
 // this ensures various parts of next.js are imported and "used" somewhere so that they wont be tree shaken out
-// node this is optional in the latest release, as it is auto-injected by NextFederationPlugin now
+// note: this is optional in the latest release, as it is auto-injected by NextFederationPlugin now
 import '@module-federation/nextjs-mf/src/include-defaults';
 ```
 
@@ -195,7 +195,7 @@ module.exports = {
 
 // _app.js or some other file in as high up in the app (like next's new layouts)
 // this ensures various parts of next.js are imported and "used" somewhere so that they wont be tree shaken out
-// node this is optional in the latest release, as it is auto-injected by NextFederationPlugin now
+// note: this is optional in the latest release, as it is auto-injected by NextFederationPlugin now
 import '@module-federation/nextjs-mf/src/include-defaults';
 ```
 

--- a/packages/nextjs-mf/README.md
+++ b/packages/nextjs-mf/README.md
@@ -195,6 +195,7 @@ module.exports = {
 
 // _app.js or some other file in as high up in the app (like next's new layouts)
 // this ensures various parts of next.js are imported and "used" somewhere so that they wont be tree shaken out
+// node this is optional in the latest release, as it is auto-injected by NextFederationPlugin now
 import '@module-federation/nextjs-mf/src/include-defaults';
 ```
 

--- a/packages/nextjs-mf/README.md
+++ b/packages/nextjs-mf/README.md
@@ -165,11 +165,12 @@ module.exports = {
 
 // _app.js or some other file in as high up in the app (like next's new layouts)
 // this ensures various parts of next.js are imported and "used" somewhere so that they wont be tree shaken out
+// node this is optional in the latest release, as it is auto-injected by NextFederationPlugin now
 import '@module-federation/nextjs-mf/src/include-defaults';
 ```
 
 2. For the consuming application, we'll call it "next1", add an instance of the ModuleFederationPlugin to your webpack config, and ensure you have a [custom Next.js App](https://nextjs.org/docs/advanced-features/custom-app) `pages/_app.js` (or `.tsx`):
-   Inside that \_app.js or layout.js file, ensure you import `include-defaults` file
+   Inside that \_app.js or layout.js file, ensure you import `include-defaults` file (this is now optional as include-defaults is auto injected into _app)
 
 ```js
 // next.config.js

--- a/packages/nextjs-mf/README.md
+++ b/packages/nextjs-mf/README.md
@@ -165,7 +165,7 @@ module.exports = {
 
 // _app.js or some other file in as high up in the app (like next's new layouts)
 // this ensures various parts of next.js are imported and "used" somewhere so that they wont be tree shaken out
-import '@module-federation/nextjs-mf/lib/include-defaults';
+import '@module-federation/nextjs-mf/src/include-defaults';
 ```
 
 2. For the consuming application, we'll call it "next1", add an instance of the ModuleFederationPlugin to your webpack config, and ensure you have a [custom Next.js App](https://nextjs.org/docs/advanced-features/custom-app) `pages/_app.js` (or `.tsx`):
@@ -194,7 +194,7 @@ module.exports = {
 
 // _app.js or some other file in as high up in the app (like next's new layouts)
 // this ensures various parts of next.js are imported and "used" somewhere so that they wont be tree shaken out
-import '@module-federation/nextjs-mf/lib/include-defaults';
+import '@module-federation/nextjs-mf/src/include-defaults';
 ```
 
 4. Use next/dynamic or low level api to import remotes.


### PR DESCRIPTION
This PR fixes the path for `include-defaults` in the examples

I've noticed in the latest version of nextjs-mf v5.12.9, the lib folder is no longer in the package, and instead, there's a src folder with the `include-defaults.js`

