### PR TITLE
fix: Typescript - Allow custom remote filename

### DIFF
--- a/packages/typescript/src/lib/normalizeOptions.ts
+++ b/packages/typescript/src/lib/normalizeOptions.ts
@@ -24,7 +24,6 @@ export const normalizeOptions = (
     'dist';
 
   const distDir = path.join(distPath, typescriptFolderName);
-  const typesIndexJsonFilePath = path.join(distDir, TYPES_INDEX_JSON_FILE_NAME);
 
   const tsCompilerOptions: ts.CompilerOptions = {
     declaration: true,
@@ -41,14 +40,11 @@ export const normalizeOptions = (
         : webpackPublicPath
       : '';
 
-  const typesStatsFileName = TYPES_INDEX_JSON_FILE_NAME;
-
   return {
     distDir,
     publicPath,
     tsCompilerOptions,
     typesIndexJsonFileName: TYPES_INDEX_JSON_FILE_NAME,
-    typesStatsFileName,
     typescriptFolderName,
     webpackCompilerOptions,
   };

--- a/packages/typescript/src/lib/normalizeOptions.ts
+++ b/packages/typescript/src/lib/normalizeOptions.ts
@@ -41,18 +41,13 @@ export const normalizeOptions = (
         : webpackPublicPath
       : '';
 
-  const remoteEntryFilename = options.federationConfig.filename;
-
-  const typesStatsFileName = remoteEntryFilename
-    ? remoteEntryFilename.replace('remoteEntry.js', TYPES_INDEX_JSON_FILE_NAME)
-    : TYPES_INDEX_JSON_FILE_NAME;
+  const typesStatsFileName = TYPES_INDEX_JSON_FILE_NAME;
 
   return {
     distDir,
     publicPath,
     tsCompilerOptions,
     typesIndexJsonFileName: TYPES_INDEX_JSON_FILE_NAME,
-    typesIndexJsonFilePath,
     typesStatsFileName,
     typescriptFolderName,
     webpackCompilerOptions,

--- a/packages/typescript/src/plugins/FederatedTypesPlugin.ts
+++ b/packages/typescript/src/plugins/FederatedTypesPlugin.ts
@@ -160,7 +160,7 @@ export class FederatedTypesPlugin {
       try {
         this.logger.log(`Getting types index for remote '${remote}'`);
         const resp = await axios.get<TypesStatsJson>(
-          `${origin}/${this.normalizeOptions.typesStatsFileName}`
+          `${origin}/${this.normalizeOptions.typesIndexJsonFileName}`
         );
 
         const statsJson = resp.data;

--- a/packages/typescript/src/plugins/FederatedTypesPlugin.ts
+++ b/packages/typescript/src/plugins/FederatedTypesPlugin.ts
@@ -119,11 +119,10 @@ export class FederatedTypesPlugin {
     const compiler = new TypescriptCompiler(this.normalizeOptions);
 
     try {
-      const filesMap = compiler.generateDeclarationFiles(
+      return compiler.generateDeclarationFiles(
         exposedComponents,
         this.options.additionalFilesToCompile
       );
-      return filesMap;
     } catch (error) {
       this.logger.error(error);
       throw error;

--- a/packages/typescript/src/plugins/FederatedTypesStatsPlugin.ts
+++ b/packages/typescript/src/plugins/FederatedTypesStatsPlugin.ts
@@ -19,7 +19,7 @@ export class FederatedTypesStatsPlugin {
           stage: Compilation.PROCESS_ASSETS_STAGE_ANALYSE,
         },
         async () => {
-          const { typesStatsFileName, publicPath } = this.options;
+          const { typesIndexJsonFileName, publicPath } = this.options;
 
           const statsJson: TypesStatsJson = {
             publicPath,
@@ -28,12 +28,12 @@ export class FederatedTypesStatsPlugin {
 
           const source = new sources.RawSource(JSON.stringify(statsJson));
 
-          const asset = compilation.getAsset(typesStatsFileName);
+          const asset = compilation.getAsset(typesIndexJsonFileName);
 
           if (asset) {
-            compilation.updateAsset(typesStatsFileName, source);
+            compilation.updateAsset(typesIndexJsonFileName, source);
           } else {
-            compilation.emitAsset(typesStatsFileName, source);
+            compilation.emitAsset(typesIndexJsonFileName, source);
           }
         }
       );


### PR DESCRIPTION
Currently the FederatedTypesStatsPlugins.js is hard coded to look for "remoteEntry.js", making a remote who uses a different filename in it's MF configuration always return a 404 while searching for the type stats json file.

The code below is the culprit:

```javascript
const typesStatsFileName = remoteEntryFilename
    ? remoteEntryFilename.replace('remoteEntry.js', TYPES_INDEX_JSON_FILE_NAME)
    : TYPES_INDEX_JSON_FILE_NAME;
```

After removing this code, the typesStatsFileName variable is no longer needed at all. The fully qualified URL is generated in the FederateTypesPlugin with the following code, this would grab the URL stripping off the remote JS file and then concatenates the TYPES_INDEX_JSON_FILE_NAME to the end of it which is the same result.

```javascript
const remoteUrls = Object.entries(remoteComponents).map(
      ([remote, entry]) => {
        const remoteUrl = entry.substring(0, entry.lastIndexOf('/'));
        const [, url] = remoteUrl.split('@');

        return {
          origin: url ?? remoteUrl,
          remote,
        };
      }
    );

.....

this.logger.log(`Getting types index for remote '${remote}'`);
        const resp = await axios.get<TypesStatsJson>(
          `${origin}/${this.normalizeOptions.typesIndexJsonFileName}`
        );
```