### PR TITLE
fix(typescript): fix parsing of tsconfig options for compiler

### DIFF
--- a/packages/typescript/src/lib/TypescriptCompiler.ts
+++ b/packages/typescript/src/lib/TypescriptCompiler.ts
@@ -158,15 +158,25 @@ export class TypescriptCompiler {
   private getTSConfigCompilerOptions(): ts.CompilerOptions {
     const context = this.options.webpackCompilerOptions.context!;
 
-    const tsconfigPath = path.resolve(context, 'tsconfig.json');
+    const tsconfigPath = ts.findConfigFile(
+      context,
+      ts.sys.fileExists,
+      'tsconfig.json'
+    );
 
     if (!tsconfigPath) {
       this.logger.error('ERROR: Could not find a valid tsconfig.json');
       process.exit(1);
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    return require(tsconfigPath).compilerOptions;
+    const readResult = ts.readConfigFile(tsconfigPath, ts.sys.readFile);
+    const configContent = ts.parseJsonConfigFileContent(
+      readResult.config,
+      ts.sys,
+      context
+    );
+
+    return configContent.options;
   }
 
   private getFilenameWithExtension(rootDir: string, entry: string) {


### PR DESCRIPTION
Fixes #408

The `moduleResolution` and `target` options being passed to the TS compiler weren't valid.  Inside the `tsconfig.json`, they are strings, but the compiler expects enums.  This fix normalizes the values after the tsconfig is read from file.
