### PR TITLE
fix(typescript): set noEmit: false when compiling types

### DIFF
--- a/packages/typescript/src/lib/normalizeOptions.ts
+++ b/packages/typescript/src/lib/normalizeOptions.ts
@@ -30,6 +30,7 @@ export const normalizeOptions = (
     declaration: true,
     emitDeclarationOnly: true,
     outDir: path.join(distDir, '/'),
+    noEmit: false,
   };
 
   const webpackPublicPath = webpackCompilerOptions.output.publicPath;


### PR DESCRIPTION
The typescript plugin merges the application's `tsconfig.json` with the default options in `normalizeOptions.ts`.

When `noEmit: true` is set in the applications tsconfig the plugin fails to emit any types, as is the expected behaviour from the TS compiler. This PR sets `noEmit` to `false` so that the plugin always emits the types, similar to the other defaults of `emitDeclarationOnly` and `declaration`

