### PR TITLE
fix(async-boundary-loader): use relativeResource instead of this.resouce

### DIFF
--- a/packages/nextjs-mf/src/loaders/async-boundary-loader.ts
+++ b/packages/nextjs-mf/src/loaders/async-boundary-loader.ts
@@ -91,7 +91,7 @@ export const pitch = function( this: LoaderContext<Record<string, unknown>>, rem
         );
 
         const result = [
-          pageTemplate(`${this.resource}?hasBoundary`)
+          pageTemplate(`${relativeResource}?hasBoundary`)
         ];
 
         if(hasGIP) {


### PR DESCRIPTION
closes #372 
closes #360 